### PR TITLE
feat(web): Template Library, Detail, and Fulfillment pages (#12, #13, #14)

### DIFF
--- a/apps/web/src/pages/TemplateDetailPage.tsx
+++ b/apps/web/src/pages/TemplateDetailPage.tsx
@@ -11,15 +11,20 @@ import {
 } from '../components/templates/templateUtils';
 import { useAuth } from '../contexts/AuthContext';
 import { hasMinimumRole } from '../rbac';
-import type { AssignTemplateResult, ProofTemplateRecord } from '../types/templates';
+import type { AssignTemplateResult, ProofTemplateRecord, TemplateAssignmentEmployeeRecord } from '../types/templates';
+import type { PaginatedResponse } from '../types/my-section';
+import { formatDate, toArray } from './pageHelpers';
 import '../styles/my-section.css';
 import '../styles/managed-pages.css';
 import '../styles/template-screens.css';
+
+type AssignmentHistoryResponse = TemplateAssignmentEmployeeRecord[] | PaginatedResponse<TemplateAssignmentEmployeeRecord>;
 
 export default function TemplateDetailPage() {
   const { id = '' } = useParams<{ id: string }>();
   const { user } = useAuth();
   const [template, setTemplate] = useState<ProofTemplateRecord | null>(null);
+  const [assignmentHistory, setAssignmentHistory] = useState<TemplateAssignmentEmployeeRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [notice, setNotice] = useState('');
@@ -32,15 +37,23 @@ export default function TemplateDetailPage() {
       setLoading(true);
 
       try {
-        const response = await api.get<ProofTemplateRecord>(`/templates/${id}`);
+        const [templateResponse, assignmentsResponse] = await Promise.all([
+          api.get<ProofTemplateRecord>(`/templates/${id}`),
+          hasMinimumRole(user?.role, 'supervisor')
+            ? api.get<AssignmentHistoryResponse>(`/templates/${id}/assignments?page=1&limit=50`)
+                .catch(() => [] as TemplateAssignmentEmployeeRecord[])
+            : Promise.resolve([] as TemplateAssignmentEmployeeRecord[]),
+        ]);
 
         if (!ignore) {
-          setTemplate(response);
+          setTemplate(templateResponse);
+          setAssignmentHistory(toArray(assignmentsResponse as AssignmentHistoryResponse));
           setError('');
         }
       } catch (fetchError) {
         if (!ignore) {
           setTemplate(null);
+          setAssignmentHistory([]);
           setError(fetchError instanceof Error ? fetchError.message : 'Failed to load template detail');
         }
       } finally {
@@ -60,7 +73,7 @@ export default function TemplateDetailPage() {
     return () => {
       ignore = true;
     };
-  }, [id]);
+  }, [id, user?.role]);
 
   const canAssignToSelf = hasMinimumRole(user?.role, 'supervisor');
   const canEditTemplate = hasMinimumRole(user?.role, 'manager');
@@ -199,6 +212,41 @@ export default function TemplateDetailPage() {
                 />
               ))}
             </section>
+
+            {hasMinimumRole(user?.role, 'supervisor') ? (
+              <section className="my-card" aria-labelledby="assignment-history-heading">
+                <div className="managed-page__section-header">
+                  <div className="managed-page__card-title">
+                    <span className="my-page__eyebrow">Assignment tracking</span>
+                    <h2 id="assignment-history-heading">Assignment history</h2>
+                  </div>
+                  <span className="my-badge">{assignmentHistory.length} assignment{assignmentHistory.length === 1 ? '' : 's'}</span>
+                </div>
+
+                {assignmentHistory.length === 0 ? (
+                  <div className="my-empty-state">No employees have been assigned this template yet.</div>
+                ) : (
+                  <div className="managed-page__list">
+                    {assignmentHistory.map((assignment) => (
+                      <article key={assignment.id} className="managed-page__list-item template-screen__employee-row">
+                        <div className="managed-page__list-copy">
+                          <strong>{assignment.employeeName || assignment.employeeEmail || 'Unknown employee'}</strong>
+                          <p className="my-page__muted">
+                            Assigned {formatDate(assignment.createdAt)} · Due {formatDate(assignment.dueDate, 'No deadline')}
+                          </p>
+                        </div>
+                        <div className="template-screen__employee-meta">
+                          {assignment.department ? <span className="my-badge">{assignment.department}</span> : null}
+                          <span className={assignment.completedAt ? 'my-badge my-badge--active' : assignment.isActive ? 'my-badge my-badge--warning' : 'my-badge'}>
+                            {assignment.completedAt ? 'Completed' : assignment.isActive ? 'Active' : 'Inactive'}
+                          </span>
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                )}
+              </section>
+            ) : null}
           </>
         ) : null}
       </div>

--- a/apps/web/src/pages/__tests__/TemplateDetailPage.test.tsx
+++ b/apps/web/src/pages/__tests__/TemplateDetailPage.test.tsx
@@ -1,0 +1,283 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from '../../contexts/AuthContext';
+import { FeatureFlagsProvider } from '../../hooks/useFeatureFlags';
+import TemplateDetailPage from '../TemplateDetailPage';
+
+vi.mock('../../api/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+const supervisorUser = {
+  id: 'supervisor-1',
+  email: 'supervisor@example.com',
+  name: 'Supervisor User',
+  role: 'supervisor',
+};
+
+const employeeUser = {
+  id: 'employee-1',
+  email: 'employee@example.com',
+  name: 'Employee User',
+  role: 'employee',
+};
+
+const template = {
+  id: 'tpl-1',
+  name: 'Forklift Operator Onboarding',
+  description: 'Full onboarding template for forklift operators.',
+  category: 'Safety',
+  status: 'published',
+  version: 2,
+  previousVersion: null,
+  createdBy: 'admin-1',
+  updatedBy: null,
+  standardId: null,
+  createdAt: '2026-03-10T00:00:00.000Z',
+  updatedAt: '2026-03-10T00:00:00.000Z',
+  publishedAt: '2026-03-12T00:00:00.000Z',
+  archivedAt: null,
+  requirements: [
+    {
+      id: 'req-1',
+      templateId: 'tpl-1',
+      name: 'OSHA 10-Hour Card',
+      description: 'Upload your OSHA card.',
+      attestationLevels: ['upload', 'validated'],
+      proofType: 'certification',
+      proofSubType: null,
+      threshold: null,
+      thresholdUnit: null,
+      rollingWindowDays: null,
+      universalCategory: null,
+      qualificationType: null,
+      medicalTestType: null,
+      standardReqId: null,
+      validityDays: 365,
+      renewalWarningDays: 30,
+      sortOrder: 0,
+      isRequired: true,
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    },
+    {
+      id: 'req-2',
+      templateId: 'tpl-1',
+      name: 'Equipment Familiarization',
+      description: 'Complete the walkthrough.',
+      attestationLevels: ['self_attest'],
+      proofType: 'training',
+      proofSubType: null,
+      threshold: null,
+      thresholdUnit: null,
+      rollingWindowDays: null,
+      universalCategory: null,
+      qualificationType: null,
+      medicalTestType: null,
+      standardReqId: null,
+      validityDays: null,
+      renewalWarningDays: null,
+      sortOrder: 1,
+      isRequired: true,
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    },
+  ],
+};
+
+const assignmentHistory = [
+  {
+    id: 'assign-1',
+    templateId: 'tpl-1',
+    templateVersion: 2,
+    employeeId: 'emp-1',
+    employeeName: 'Jane Smith',
+    employeeEmail: 'jane@example.com',
+    role: 'employee',
+    department: 'Operations',
+    assignedBy: 'supervisor-1',
+    dueDate: '2026-04-15T00:00:00.000Z',
+    isActive: true,
+    createdAt: '2026-03-20T00:00:00.000Z',
+    updatedAt: '2026-03-20T00:00:00.000Z',
+    completedAt: null,
+  },
+  {
+    id: 'assign-2',
+    templateId: 'tpl-1',
+    templateVersion: 1,
+    employeeId: 'emp-2',
+    employeeName: 'John Doe',
+    employeeEmail: 'john@example.com',
+    role: 'employee',
+    department: 'Warehouse',
+    assignedBy: 'supervisor-1',
+    dueDate: null,
+    isActive: false,
+    createdAt: '2026-03-01T00:00:00.000Z',
+    updatedAt: '2026-03-15T00:00:00.000Z',
+    completedAt: '2026-03-14T00:00:00.000Z',
+  },
+];
+
+function mockApi(options?: {
+  user?: typeof supervisorUser;
+  failTemplate?: boolean;
+  failAssignments?: boolean;
+  assignmentsResponse?: typeof assignmentHistory;
+}) {
+  return import('../../api/client').then(({ api }) => {
+    vi.mocked(api.get).mockImplementation((path: string) => {
+      if (path === '/v1/platform/feature-flags') {
+        return Promise.resolve({ 'compliance.templates': true });
+      }
+
+      if (path === '/templates/tpl-1') {
+        if (options?.failTemplate) {
+          return Promise.reject(new Error('Template not found'));
+        }
+        return Promise.resolve(template);
+      }
+
+      if (path.startsWith('/templates/tpl-1/assignments')) {
+        if (options?.failAssignments) {
+          return Promise.reject(new Error('Assignments unavailable'));
+        }
+        return Promise.resolve(options?.assignmentsResponse ?? assignmentHistory);
+      }
+
+      return Promise.reject(new Error(`Unexpected path: ${path}`));
+    });
+
+    vi.mocked(api.post).mockImplementation((path: string) => {
+      if (path === '/templates/tpl-1/assign') {
+        return Promise.resolve({ assignments: [], created: 1, skipped: 0 });
+      }
+
+      return Promise.reject(new Error(`Unexpected POST path: ${path}`));
+    });
+  });
+}
+
+function Wrapper({ children, initialPath = '/templates/tpl-1' }: { children: ReactNode; initialPath?: string }) {
+  return (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AuthProvider>
+        <FeatureFlagsProvider>{children}</FeatureFlagsProvider>
+      </AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderDetail(options?: { user?: typeof supervisorUser; initialPath?: string }) {
+  localStorage.setItem('user', JSON.stringify(options?.user ?? supervisorUser));
+  localStorage.setItem('token', 'fake-token');
+
+  return render(
+    <Wrapper initialPath={options?.initialPath}>
+      <Routes>
+        <Route path="/templates/:id" element={<TemplateDetailPage />} />
+      </Routes>
+    </Wrapper>,
+  );
+}
+
+describe('TemplateDetailPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders template overview with name, description, and requirements', async () => {
+    await mockApi();
+    renderDetail();
+
+    expect(screen.getByText(/loading template detail/i)).toBeInTheDocument();
+    const headings = await screen.findAllByRole('heading', { name: /forklift operator onboarding/i });
+    expect(headings.length).toBeGreaterThan(0);
+    expect(screen.getByText(/full onboarding template for forklift operators/i)).toBeInTheDocument();
+    expect(screen.getByText('OSHA 10-Hour Card')).toBeInTheDocument();
+    expect(screen.getByText('Equipment Familiarization')).toBeInTheDocument();
+  });
+
+  it('shows requirement attestation badges and metadata', async () => {
+    await mockApi();
+    renderDetail();
+
+    await screen.findByText('OSHA 10-Hour Card');
+    expect(screen.getByText('2 attestation steps')).toBeInTheDocument();
+    expect(screen.getByText('1 attestation steps')).toBeInTheDocument();
+    expect(screen.getByText('365 days')).toBeInTheDocument();
+  });
+
+  it('shows assignment history for supervisors', async () => {
+    await mockApi();
+    renderDetail();
+
+    expect(await screen.findByRole('heading', { name: /assignment history/i })).toBeInTheDocument();
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('Operations')).toBeInTheDocument();
+    expect(screen.getByText('Warehouse')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+    expect(screen.getByText(/2 assignments/i)).toBeInTheDocument();
+  });
+
+  it('hides assignment history for employees', async () => {
+    await mockApi({ user: employeeUser });
+    renderDetail({ user: employeeUser });
+
+    const headings = await screen.findAllByRole('heading', { name: /forklift operator onboarding/i });
+    expect(headings.length).toBeGreaterThan(0);
+    expect(screen.queryByRole('heading', { name: /assignment history/i })).not.toBeInTheDocument();
+  });
+
+  it('shows assign and edit actions for supervisors and managers', async () => {
+    await mockApi();
+    renderDetail();
+
+    const headings = await screen.findAllByRole('heading', { name: /forklift operator onboarding/i });
+    expect(headings.length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: /open assign flow/i })).toBeInTheDocument();
+  });
+
+  it('allows self-assignment for supervisors', async () => {
+    await mockApi();
+    const user = userEvent.setup();
+    renderDetail();
+
+    const assignButton = await screen.findByRole('button', { name: /assign to me/i });
+    await user.click(assignButton);
+
+    await waitFor(() => {
+      expect(screen.getByText(/template assigned to you successfully/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when template cannot be loaded', async () => {
+    await mockApi({ failTemplate: true });
+    renderDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText(/template not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('gracefully handles assignment history fetch failure', async () => {
+    await mockApi({ failAssignments: true });
+    renderDetail();
+
+    const headings = await screen.findAllByRole('heading', { name: /forklift operator onboarding/i });
+    expect(headings.length).toBeGreaterThan(0);
+    // Assignment history section still renders with empty state
+    expect(await screen.findByRole('heading', { name: /assignment history/i })).toBeInTheDocument();
+    expect(screen.getByText(/no employees have been assigned/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/__tests__/TemplateFulfillmentPage.test.tsx
+++ b/apps/web/src/pages/__tests__/TemplateFulfillmentPage.test.tsx
@@ -1,0 +1,303 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from '../../contexts/AuthContext';
+import { FeatureFlagsProvider } from '../../hooks/useFeatureFlags';
+import TemplateFulfillmentPage from '../TemplateFulfillmentPage';
+
+vi.mock('../../api/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+const employeeUser = {
+  id: 'employee-1',
+  email: 'employee@example.com',
+  name: 'Employee User',
+  role: 'employee',
+};
+
+const assignment = {
+  id: 'assignment-1',
+  templateId: 'tpl-1',
+  templateVersion: 2,
+  employeeId: 'employee-1',
+  role: null,
+  department: null,
+  assignedBy: 'manager-1',
+  dueDate: '2026-04-15T00:00:00.000Z',
+  isActive: true,
+  createdAt: '2026-03-20T00:00:00.000Z',
+  updatedAt: '2026-03-20T00:00:00.000Z',
+  completedAt: null,
+  templateName: 'Forklift Operator Onboarding',
+  templateStatus: 'published',
+};
+
+const template = {
+  id: 'tpl-1',
+  name: 'Forklift Operator Onboarding',
+  description: 'Full onboarding template for forklift operators.',
+  category: 'Safety',
+  status: 'published',
+  version: 2,
+  previousVersion: null,
+  createdBy: 'admin-1',
+  updatedBy: null,
+  standardId: null,
+  createdAt: '2026-03-10T00:00:00.000Z',
+  updatedAt: '2026-03-10T00:00:00.000Z',
+  publishedAt: '2026-03-12T00:00:00.000Z',
+  archivedAt: null,
+  requirements: [
+    {
+      id: 'req-1',
+      templateId: 'tpl-1',
+      name: 'OSHA 10-Hour Card',
+      description: 'Upload your OSHA card.',
+      attestationLevels: ['upload'],
+      proofType: 'certification',
+      proofSubType: null,
+      threshold: null,
+      thresholdUnit: null,
+      rollingWindowDays: null,
+      universalCategory: null,
+      qualificationType: null,
+      medicalTestType: null,
+      standardReqId: null,
+      validityDays: 365,
+      renewalWarningDays: 30,
+      sortOrder: 0,
+      isRequired: true,
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    },
+    {
+      id: 'req-2',
+      templateId: 'tpl-1',
+      name: 'Equipment Familiarization',
+      description: 'Complete the walkthrough.',
+      attestationLevels: ['self_attest'],
+      proofType: 'training',
+      proofSubType: null,
+      threshold: null,
+      thresholdUnit: null,
+      rollingWindowDays: null,
+      universalCategory: null,
+      qualificationType: null,
+      medicalTestType: null,
+      standardReqId: null,
+      validityDays: null,
+      renewalWarningDays: null,
+      sortOrder: 1,
+      isRequired: true,
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    },
+  ],
+};
+
+const fulfillments = [
+  {
+    id: 'ful-1',
+    assignmentId: 'assignment-1',
+    requirementId: 'req-1',
+    employeeId: 'employee-1',
+    status: 'fulfilled',
+    selfAttestedAt: null,
+    uploadedAt: '2026-03-22T00:00:00.000Z',
+    documentId: 'doc-1',
+    attachedDocumentId: 'doc-1',
+    thirdPartyVerifiedAt: null,
+    validatedAt: null,
+    rejectedAt: null,
+    rejectionReason: null,
+    expiresAt: null,
+    createdAt: '2026-03-20T00:00:00.000Z',
+    updatedAt: '2026-03-22T00:00:00.000Z',
+  },
+  {
+    id: 'ful-2',
+    assignmentId: 'assignment-1',
+    requirementId: 'req-2',
+    employeeId: 'employee-1',
+    status: 'unfulfilled',
+    selfAttestedAt: null,
+    uploadedAt: null,
+    documentId: null,
+    attachedDocumentId: null,
+    thirdPartyVerifiedAt: null,
+    validatedAt: null,
+    rejectedAt: null,
+    rejectionReason: null,
+    expiresAt: null,
+    createdAt: '2026-03-20T00:00:00.000Z',
+    updatedAt: '2026-03-20T00:00:00.000Z',
+  },
+];
+
+const documents = [
+  {
+    id: 'doc-1',
+    employeeId: 'employee-1',
+    name: 'osha-card.pdf',
+    fileName: 'osha-card.pdf',
+    status: 'approved',
+    createdAt: '2026-03-22T00:00:00.000Z',
+  },
+];
+
+function mockApi(options?: { failLoad?: boolean }) {
+  return import('../../api/client').then(({ api }) => {
+    vi.mocked(api.get).mockImplementation((path: string) => {
+      if (path === '/v1/platform/feature-flags') {
+        return Promise.resolve({ 'compliance.templates': true });
+      }
+
+      if (path.startsWith('/employees/employee-1/assignments')) {
+        if (options?.failLoad) {
+          return Promise.reject(new Error('Assignments unavailable'));
+        }
+        return Promise.resolve({ data: [assignment], total: 1, page: 1, limit: 100 });
+      }
+
+      if (path === '/templates/tpl-1') {
+        return Promise.resolve(template);
+      }
+
+      if (path === '/assignments/assignment-1/fulfillments') {
+        return Promise.resolve(fulfillments);
+      }
+
+      if (path.startsWith('/documents/employee/employee-1')) {
+        return Promise.resolve(documents);
+      }
+
+      return Promise.reject(new Error(`Unexpected path: ${path}`));
+    });
+
+    vi.mocked(api.post).mockImplementation((path: string) => {
+      if (path.includes('/self-attest')) {
+        return Promise.resolve({});
+      }
+
+      if (path.includes('/attach-document')) {
+        return Promise.resolve({});
+      }
+
+      if (path === '/documents/upload') {
+        return Promise.resolve({ id: 'doc-new', name: 'evidence.pdf', status: 'uploaded' });
+      }
+
+      return Promise.reject(new Error(`Unexpected POST path: ${path}`));
+    });
+  });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={['/me/templates/assignment-1']}>
+      <AuthProvider>
+        <FeatureFlagsProvider>{children}</FeatureFlagsProvider>
+      </AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderFulfillment() {
+  localStorage.setItem('user', JSON.stringify(employeeUser));
+  localStorage.setItem('token', 'fake-token');
+
+  return render(
+    <Wrapper>
+      <Routes>
+        <Route path="/me/templates/:assignmentId" element={<TemplateFulfillmentPage />} />
+      </Routes>
+    </Wrapper>,
+  );
+}
+
+describe('TemplateFulfillmentPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders assignment overview with progress bar and requirement panels', async () => {
+    await mockApi();
+    renderFulfillment();
+
+    expect(screen.getByText(/loading template fulfillment/i)).toBeInTheDocument();
+    const headings = await screen.findAllByRole('heading', { name: /forklift operator onboarding/i });
+    expect(headings.length).toBeGreaterThan(0);
+    expect(screen.getByText(/50% complete/i)).toBeInTheDocument();
+    expect(screen.getByText('OSHA 10-Hour Card')).toBeInTheDocument();
+    expect(screen.getByText('Equipment Familiarization')).toBeInTheDocument();
+  });
+
+  it('shows fulfilled and not started status badges for requirements', async () => {
+    await mockApi();
+    renderFulfillment();
+
+    await screen.findByText('OSHA 10-Hour Card');
+    expect(screen.getByText('Fulfilled')).toBeInTheDocument();
+    expect(screen.getByText('Not started')).toBeInTheDocument();
+  });
+
+  it('shows self-attestation form for requirements with self_attest level', async () => {
+    await mockApi();
+    renderFulfillment();
+
+    await screen.findByText('Equipment Familiarization');
+    expect(screen.getByPlaceholderText(/describe how you met this requirement/i)).toBeInTheDocument();
+  });
+
+  it('shows due date and assignment summary fields', async () => {
+    await mockApi();
+    renderFulfillment();
+
+    const headings = await screen.findAllByRole('heading', { name: /forklift operator onboarding/i });
+    expect(headings.length).toBeGreaterThan(0);
+    expect(screen.getByText(/due date/i)).toBeInTheDocument();
+    expect(screen.getByText('1 / 2')).toBeInTheDocument(); // Completed count
+  });
+
+  it('shows evidence document linked to a fulfilled requirement', async () => {
+    await mockApi();
+    renderFulfillment();
+
+    await screen.findByText('osha-card.pdf');
+    expect(screen.getByText('Uploaded')).toBeInTheDocument();
+  });
+
+  it('shows save and submit action buttons', async () => {
+    await mockApi();
+    renderFulfillment();
+
+    const headings = await screen.findAllByRole('heading', { name: /forklift operator onboarding/i });
+    expect(headings.length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /save progress/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /submit progress/i })).toBeInTheDocument();
+  });
+
+  it('shows error state when assignment cannot be loaded', async () => {
+    await mockApi({ failLoad: true });
+    renderFulfillment();
+
+    await waitFor(() => {
+      expect(screen.getByText(/assignments unavailable/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows back-to-templates navigation link', async () => {
+    await mockApi();
+    renderFulfillment();
+
+    const headings = await screen.findAllByRole('heading', { name: /forklift operator onboarding/i });
+    expect(headings.length).toBeGreaterThan(0);
+    expect(screen.getByRole('link', { name: /back to templates/i })).toHaveAttribute('href', '/me/templates');
+  });
+});

--- a/apps/web/src/pages/__tests__/TemplateLibraryPage.test.tsx
+++ b/apps/web/src/pages/__tests__/TemplateLibraryPage.test.tsx
@@ -1,0 +1,248 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { AuthProvider } from '../../contexts/AuthContext';
+import { FeatureFlagsProvider } from '../../hooks/useFeatureFlags';
+import TemplateLibraryPage from '../TemplateLibraryPage';
+
+vi.mock('../../api/client', () => ({
+  api: { get: vi.fn() },
+  ApiError: class ApiError extends Error {
+    constructor(message: string, public status: number) {
+      super(message);
+      this.name = 'ApiError';
+    }
+  },
+}));
+
+const supervisorUser = {
+  id: 'supervisor-1',
+  email: 'supervisor@example.com',
+  name: 'Supervisor User',
+  role: 'supervisor',
+};
+
+const templates = [
+  {
+    id: 'tpl-1',
+    name: 'Forklift Operator Onboarding',
+    description: 'Requirements for forklift operators.',
+    category: 'Safety',
+    status: 'published',
+    version: 2,
+    previousVersion: null,
+    createdBy: 'admin-1',
+    updatedBy: null,
+    standardId: null,
+    createdAt: '2026-03-10T00:00:00.000Z',
+    updatedAt: '2026-03-10T00:00:00.000Z',
+    publishedAt: '2026-03-12T00:00:00.000Z',
+    archivedAt: null,
+    requirements: [
+      {
+        id: 'req-1',
+        templateId: 'tpl-1',
+        name: 'OSHA 10-Hour Card',
+        description: 'Upload your OSHA card.',
+        attestationLevels: ['upload'],
+        proofType: 'certification',
+        proofSubType: null,
+        threshold: null,
+        thresholdUnit: null,
+        rollingWindowDays: null,
+        universalCategory: null,
+        qualificationType: null,
+        medicalTestType: null,
+        standardReqId: null,
+        validityDays: 365,
+        renewalWarningDays: 30,
+        sortOrder: 0,
+        isRequired: true,
+        createdAt: '2026-03-10T00:00:00.000Z',
+        updatedAt: '2026-03-10T00:00:00.000Z',
+      },
+    ],
+  },
+  {
+    id: 'tpl-2',
+    name: 'Annual Drug Testing',
+    description: 'Drug clearance template for all staff.',
+    category: 'Medical',
+    status: 'draft',
+    version: 1,
+    previousVersion: null,
+    createdBy: 'admin-1',
+    updatedBy: null,
+    standardId: null,
+    createdAt: '2026-03-15T00:00:00.000Z',
+    updatedAt: '2026-03-15T00:00:00.000Z',
+    publishedAt: null,
+    archivedAt: null,
+    requirements: [
+      {
+        id: 'req-2',
+        templateId: 'tpl-2',
+        name: 'Drug Test Clearance',
+        description: 'Record clearance.',
+        attestationLevels: ['third_party'],
+        proofType: 'clearance',
+        proofSubType: null,
+        threshold: null,
+        thresholdUnit: null,
+        rollingWindowDays: null,
+        universalCategory: null,
+        qualificationType: null,
+        medicalTestType: null,
+        standardReqId: null,
+        validityDays: 365,
+        renewalWarningDays: 30,
+        sortOrder: 0,
+        isRequired: true,
+        createdAt: '2026-03-15T00:00:00.000Z',
+        updatedAt: '2026-03-15T00:00:00.000Z',
+      },
+    ],
+  },
+];
+
+function mockApi(options?: { failTemplates?: boolean; templatesResponse?: typeof templates }) {
+  return import('../../api/client').then(({ api }) => {
+    vi.mocked(api.get).mockImplementation((path: string) => {
+      if (path === '/v1/platform/feature-flags') {
+        return Promise.resolve({ 'compliance.templates': true });
+      }
+
+      if (path.startsWith('/templates')) {
+        if (options?.failTemplates) {
+          return Promise.reject(new Error('Templates unavailable'));
+        }
+
+        return Promise.resolve(options?.templatesResponse ?? templates);
+      }
+
+      return Promise.reject(new Error(`Unexpected path: ${path}`));
+    });
+  });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={['/templates']}>
+      <AuthProvider>
+        <FeatureFlagsProvider>{children}</FeatureFlagsProvider>
+      </AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+describe('TemplateLibraryPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem('user', JSON.stringify(supervisorUser));
+    localStorage.setItem('token', 'fake-token');
+  });
+
+  it('renders template cards with names, categories, and status badges', async () => {
+    await mockApi();
+
+    render(
+      <Wrapper>
+        <TemplateLibraryPage />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText(/loading template library/i)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /template library/i })).toBeInTheDocument();
+    expect(screen.getByText('Forklift Operator Onboarding')).toBeInTheDocument();
+    expect(screen.getByText('Annual Drug Testing')).toBeInTheDocument();
+    expect(screen.getAllByText('Safety').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Medical').length).toBeGreaterThan(0);
+  });
+
+  it('shows summary statistics for templates', async () => {
+    await mockApi();
+
+    render(
+      <Wrapper>
+        <TemplateLibraryPage />
+      </Wrapper>,
+    );
+
+    await screen.findByText('Forklift Operator Onboarding');
+    const statValues = screen.getAllByText('2');
+    expect(statValues.length).toBeGreaterThan(0);
+  });
+
+  it('filters templates by search query', async () => {
+    await mockApi();
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <TemplateLibraryPage />
+      </Wrapper>,
+    );
+
+    await screen.findByText('Forklift Operator Onboarding');
+
+    const searchInput = screen.getByPlaceholderText(/search by name/i);
+    await user.type(searchInput, 'Drug');
+
+    expect(screen.getByText('Annual Drug Testing')).toBeInTheDocument();
+    expect(screen.queryByText('Forklift Operator Onboarding')).not.toBeInTheDocument();
+  });
+
+  it('filters templates by proof type', async () => {
+    await mockApi();
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <TemplateLibraryPage />
+      </Wrapper>,
+    );
+
+    await screen.findByText('Forklift Operator Onboarding');
+
+    const proofTypeSelect = screen.getByRole('combobox', { name: /proof type/i });
+    await user.selectOptions(proofTypeSelect, 'clearance');
+
+    expect(screen.getByText('Annual Drug Testing')).toBeInTheDocument();
+    expect(screen.queryByText('Forklift Operator Onboarding')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when no templates match filters', async () => {
+    await mockApi();
+    const user = userEvent.setup();
+
+    render(
+      <Wrapper>
+        <TemplateLibraryPage />
+      </Wrapper>,
+    );
+
+    await screen.findByText('Forklift Operator Onboarding');
+
+    const searchInput = screen.getByPlaceholderText(/search by name/i);
+    await user.type(searchInput, 'nonexistent template xyz');
+
+    expect(screen.getByText(/no templates matched your current filters/i)).toBeInTheDocument();
+  });
+
+  it('shows error state when templates cannot be loaded', async () => {
+    await mockApi({ failTemplates: true });
+
+    render(
+      <Wrapper>
+        <TemplateLibraryPage />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/templates unavailable/i)).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three template UI pages for the compliance proof template workflow.

### Template Library (/templates)
- Lists all proof templates with search, proof type filter, and category filter
- Summary stats (total templates, published count, categories)
- Card grid layout linking to template detail

### Template Detail (/templates/:id)
- Template overview with name, description, status badge, version
- Full requirements list with attestation levels, validity periods
- New: Assignment history section - supervisors+ see assigned employees, status, and department
- Self-assign and edit actions gated by role

### Template Fulfillment (/me/templates/:assignmentId)
- Employee self-service fulfillment with progress bar
- Self-attestation form for self_attest requirements
- Evidence upload for upload requirements with document linking
- Draft save to localStorage, batch submit for review
- Breadcrumb navigation back to My Templates

### Testing
- 22 new tests across 3 test files
- Covers rendering, filtering, RBAC gating, error states, navigation
- All 58 web tests pass (0 regressions)

### Routes
All routes were already wired in App.tsx with FeatureGate and ProtectedRoute.

Resolves #12, resolves #13, resolves #14