### PR TITLE
feat(web): Template management pages — Editor, Assign, Team Templates

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,6 +13,7 @@ import TemplateLibraryPage from './pages/TemplateLibraryPage';
 import TemplateDetailPage from './pages/TemplateDetailPage';
 import TemplateEditorPage from './pages/TemplateEditorPage';
 import TemplateAssignPage from './pages/TemplateAssignPage';
+import TeamTemplatesPage from './pages/TeamTemplatesPage';
 import TemplatesFeatureUnavailablePage from './pages/TemplatesFeatureUnavailablePage';
 import {
   MyDocumentsPage,
@@ -166,6 +167,16 @@ function App() {
           element={
             <ProtectedRoute minRole="supervisor">
               <TeamDirectoryPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/team/templates"
+          element={
+            <ProtectedRoute minRole="supervisor">
+              <FeatureGate flag="compliance.templates" fallback={<TemplatesFeatureUnavailablePage />}>
+                <TeamTemplatesPage />
+              </FeatureGate>
             </ProtectedRoute>
           }
         />

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -16,10 +16,11 @@ export default function Layout({ children }: LayoutProps) {
 
   const navItems = [
     canAccessTeam ? { path: '/team', label: 'Team' } : null,
+    canAccessTeam ? { path: '/team/templates', label: 'Team Templates', flag: 'compliance.templates' } : null,
     canReviewDocuments ? { path: '/reviews', label: 'Document Review' } : null,
     { path: '/standards', label: 'Standards' },
     { path: '/me/notifications', label: 'Notifications' },
-  ].filter((item): item is { path: string; label: string } => item !== null);
+  ].filter((item): item is { path: string; label: string; flag?: string } => item !== null);
 
   const renderNavLink = (path: string, label: string) => (
     <NavLink key={path} to={path} end={path === '/'} className={({ isActive }) => (isActive ? 'active' : '')}>
@@ -47,7 +48,15 @@ export default function Layout({ children }: LayoutProps) {
           >
             {renderNavLink('/me/templates', 'My Templates')}
           </FeatureGate>
-          {navItems.map((item) => renderNavLink(item.path, item.label))}
+          {navItems.map((item) =>
+            item.flag ? (
+              <FeatureGate key={item.path} flag={item.flag} fallback={null}>
+                {renderNavLink(item.path, item.label)}
+              </FeatureGate>
+            ) : (
+              renderNavLink(item.path, item.label)
+            ),
+          )}
         </nav>
       </aside>
 

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -63,8 +63,8 @@ const QUICK_ACTIONS: Record<AppRole, QuickActionDefinition[]> = {
     },
     {
       title: 'Team Templates',
-      description: 'Browse standards and requirement templates to support your team workflow.',
-      to: '/standards',
+      description: 'Monitor team assignment progress and compliance status across your reports.',
+      to: '/team/templates',
       flag: 'compliance.templates',
       disabledDescription: 'Template assignment workflows are still being staged for supervisors.',
     },

--- a/apps/web/src/pages/TeamTemplatesPage.tsx
+++ b/apps/web/src/pages/TeamTemplatesPage.tsx
@@ -1,0 +1,349 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { api, ApiError } from '../api/client';
+import PageShell from '../components/PageShell';
+import { formatDate, getDaysUntil, toTitleCase } from './pageHelpers';
+import '../styles/my-section.css';
+import '../styles/managed-pages.css';
+import '../styles/template-screens.css';
+
+interface TeamAssignmentProgress {
+  id: string;
+  templateId: string;
+  templateName: string;
+  status: string;
+  dueDate: string | null;
+  completedAt: string | null;
+  totalRequirements: number;
+  fulfilledRequirements: number;
+  completionPercentage: number;
+  isOverdue: boolean;
+  isAtRisk: boolean;
+}
+
+interface TeamTemplateProgress {
+  employeeId: string;
+  employeeName: string;
+  employeeEmail: string;
+  assignments: TeamAssignmentProgress[];
+  overallCompletionPercentage: number;
+}
+
+interface TeamTemplateRow {
+  assignmentId: string;
+  employeeId: string;
+  employeeName: string;
+  employeeEmail: string;
+  templateId: string;
+  templateName: string;
+  status: string;
+  dueDate: string | null;
+  completedAt: string | null;
+  totalRequirements: number;
+  fulfilledRequirements: number;
+  completionPercentage: number;
+  isOverdue: boolean;
+  isAtRisk: boolean;
+}
+
+function flattenTeamData(employees: TeamTemplateProgress[]): TeamTemplateRow[] {
+  const rows: TeamTemplateRow[] = [];
+
+  for (const employee of employees) {
+    for (const assignment of employee.assignments) {
+      rows.push({
+        assignmentId: assignment.id,
+        employeeId: employee.employeeId,
+        employeeName: employee.employeeName,
+        employeeEmail: employee.employeeEmail,
+        templateId: assignment.templateId,
+        templateName: assignment.templateName,
+        status: assignment.status,
+        dueDate: assignment.dueDate,
+        completedAt: assignment.completedAt,
+        totalRequirements: assignment.totalRequirements,
+        fulfilledRequirements: assignment.fulfilledRequirements,
+        completionPercentage: assignment.completionPercentage,
+        isOverdue: assignment.isOverdue,
+        isAtRisk: assignment.isAtRisk,
+      });
+    }
+  }
+
+  return rows;
+}
+
+function getStatusBadgeClass(status: string, isOverdue: boolean, isAtRisk: boolean): string {
+  if (status === 'completed') return 'my-badge my-badge--active';
+  if (isOverdue) return 'my-badge my-badge--expired';
+  if (isAtRisk) return 'my-badge my-badge--warning';
+  return 'my-badge';
+}
+
+function getStatusLabel(status: string, isOverdue: boolean, isAtRisk: boolean): string {
+  if (isOverdue) return 'Overdue';
+  if (status === 'completed') return 'Completed';
+  if (isAtRisk) return 'At Risk';
+  return toTitleCase(status);
+}
+
+function buildTemplateOptions(rows: TeamTemplateRow[]): string[] {
+  const names = new Set(rows.map((row) => row.templateName));
+  return Array.from(names).sort();
+}
+
+export default function TeamTemplatesPage() {
+  const [employees, setEmployees] = useState<TeamTemplateProgress[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [templateFilter, setTemplateFilter] = useState('all');
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function fetchTeamTemplates() {
+      setLoading(true);
+
+      try {
+        const response = await api.get<{ data: TeamTemplateProgress[] }>('/templates/team?page=1&limit=200');
+
+        if (!ignore) {
+          setEmployees(response.data);
+          setError('');
+        }
+      } catch (fetchError) {
+        if (!ignore) {
+          setEmployees([]);
+
+          if (fetchError instanceof ApiError && fetchError.status === 403) {
+            setError('Team template view is limited to supervisors and above.');
+          } else {
+            setError(fetchError instanceof Error ? fetchError.message : 'Failed to load team templates');
+          }
+        }
+      } finally {
+        if (!ignore) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void fetchTeamTemplates();
+
+    return () => {
+      ignore = true;
+    };
+  }, []);
+
+  const allRows = useMemo(() => flattenTeamData(employees), [employees]);
+  const templateOptions = useMemo(() => buildTemplateOptions(allRows), [allRows]);
+
+  const filteredRows = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+
+    return allRows.filter((row) => {
+      if (query.length > 0) {
+        const matchesSearch =
+          row.employeeName.toLowerCase().includes(query) ||
+          row.employeeEmail.toLowerCase().includes(query) ||
+          row.templateName.toLowerCase().includes(query);
+
+        if (!matchesSearch) return false;
+      }
+
+      if (statusFilter !== 'all') {
+        if (statusFilter === 'overdue' && !row.isOverdue) return false;
+        if (statusFilter === 'at_risk' && !row.isAtRisk) return false;
+        if (statusFilter === 'completed' && row.status !== 'completed') return false;
+        if (statusFilter === 'in_progress' && (row.status !== 'in_progress' || row.isOverdue || row.isAtRisk))
+          return false;
+      }
+
+      if (templateFilter !== 'all' && row.templateName !== templateFilter) return false;
+
+      return true;
+    });
+  }, [allRows, searchQuery, statusFilter, templateFilter]);
+
+  const summaryStats = useMemo(() => {
+    const uniqueEmployees = new Set(allRows.map((row) => row.employeeId)).size;
+    const totalAssignments = allRows.length;
+    const overdueCount = allRows.filter((row) => row.isOverdue).length;
+    const atRiskCount = allRows.filter((row) => row.isAtRisk).length;
+    const completedCount = allRows.filter((row) => row.status === 'completed').length;
+
+    return { uniqueEmployees, totalAssignments, overdueCount, atRiskCount, completedCount };
+  }, [allRows]);
+
+  if (loading) {
+    return (
+      <PageShell title="Team Templates" description="Monitor team assignment progress and compliance status.">
+        <div className="loading">Loading team templates...</div>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell
+      title="Team Templates"
+      description="Monitor team assignment progress and compliance status across your direct reports."
+      breadcrumbs={[
+        { label: 'Dashboard', to: '/' },
+        { label: 'Team', to: '/team' },
+        { label: 'Templates' },
+      ]}
+      actions={
+        <Link to="/templates" className="my-btn my-btn--secondary">
+          Template Library
+        </Link>
+      }
+    >
+      <div className="managed-page template-screen">
+        {error ? <div className="error">Error: {error}</div> : null}
+
+        <div className="managed-page__summary-grid" aria-label="Team template summary">
+          <div className="my-card">
+            <span className="my-page__eyebrow">Employees</span>
+            <span className="my-page__field-value">{summaryStats.uniqueEmployees}</span>
+          </div>
+          <div className="my-card">
+            <span className="my-page__eyebrow">Assignments</span>
+            <span className="my-page__field-value">{summaryStats.totalAssignments}</span>
+          </div>
+          <div className="my-card">
+            <span className="my-page__eyebrow">Completed</span>
+            <span className="my-page__field-value">{summaryStats.completedCount}</span>
+          </div>
+          <div className="my-card">
+            <span className="my-page__eyebrow">Overdue</span>
+            <span className="my-page__field-value">{summaryStats.overdueCount}</span>
+          </div>
+          <div className="my-card">
+            <span className="my-page__eyebrow">At Risk</span>
+            <span className="my-page__field-value">{summaryStats.atRiskCount}</span>
+          </div>
+        </div>
+
+        <section className="my-card" aria-labelledby="team-templates-table">
+          <div className="managed-page__section-header">
+            <div>
+              <h2 id="team-templates-table">Assignment Overview</h2>
+              <p className="my-page__muted">
+                Showing {filteredRows.length} of {allRows.length} assignment(s)
+              </p>
+            </div>
+          </div>
+
+          <div className="template-screen__upload-row">
+            <label className="my-form__group">
+              <span>Search</span>
+              <input
+                className="managed-page__search-input"
+                placeholder="Search by employee or template name"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+              />
+            </label>
+            <label className="my-form__group">
+              <span>Status</span>
+              <select
+                aria-label="Status filter"
+                value={statusFilter}
+                onChange={(event) => setStatusFilter(event.target.value)}
+              >
+                <option value="all">All statuses</option>
+                <option value="in_progress">In progress</option>
+                <option value="completed">Completed</option>
+                <option value="overdue">Overdue</option>
+                <option value="at_risk">At risk</option>
+              </select>
+            </label>
+            <label className="my-form__group">
+              <span>Template</span>
+              <select
+                aria-label="Template filter"
+                value={templateFilter}
+                onChange={(event) => setTemplateFilter(event.target.value)}
+              >
+                <option value="all">All templates</option>
+                {templateOptions.map((name) => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+
+          {filteredRows.length === 0 ? (
+            <p className="my-page__muted">No assignments match the current filters.</p>
+          ) : (
+            <div className="managed-page__table-wrapper">
+              <table className="managed-page__table" aria-label="Team template assignments">
+                <thead>
+                  <tr>
+                    <th>Employee</th>
+                    <th>Template</th>
+                    <th>Status</th>
+                    <th>Progress</th>
+                    <th>Due Date</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredRows.map((row) => (
+                    <tr key={row.assignmentId}>
+                      <td>
+                        <div>
+                          <Link to={`/team/${row.employeeId}`}>{row.employeeName}</Link>
+                          <p className="my-page__muted">{row.employeeEmail}</p>
+                        </div>
+                      </td>
+                      <td>
+                        <Link to={`/templates/${row.templateId}`}>{row.templateName}</Link>
+                      </td>
+                      <td>
+                        <span className={getStatusBadgeClass(row.status, row.isOverdue, row.isAtRisk)}>
+                          {getStatusLabel(row.status, row.isOverdue, row.isAtRisk)}
+                        </span>
+                      </td>
+                      <td>
+                        <div className="template-screen__progress-cell">
+                          <div className="template-screen__progress-bar" aria-label={`${row.completionPercentage}% complete`}>
+                            <div
+                              className="template-screen__progress-fill"
+                              style={{ width: `${row.completionPercentage}%` }}
+                            />
+                          </div>
+                          <span className="my-page__muted">
+                            {row.fulfilledRequirements}/{row.totalRequirements}
+                          </span>
+                        </div>
+                      </td>
+                      <td>
+                        {row.dueDate ? (
+                          <span className={getDaysUntil(row.dueDate) < 0 ? 'my-page__muted my-page__overdue' : ''}>
+                            {formatDate(row.dueDate)}
+                          </span>
+                        ) : (
+                          <span className="my-page__muted">No deadline</span>
+                        )}
+                      </td>
+                      <td>
+                        <Link to={`/templates/${row.templateId}`} className="my-btn my-btn--secondary my-btn--small">
+                          View
+                        </Link>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </div>
+    </PageShell>
+  );
+}

--- a/apps/web/src/pages/__tests__/TeamTemplatesPage.test.tsx
+++ b/apps/web/src/pages/__tests__/TeamTemplatesPage.test.tsx
@@ -1,0 +1,306 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from '../../contexts/AuthContext';
+import { FeatureFlagsProvider } from '../../hooks/useFeatureFlags';
+import TeamTemplatesPage from '../TeamTemplatesPage';
+
+vi.mock('../../api/client', () => ({
+  api: {
+    get: vi.fn(),
+  },
+  ApiError: class extends Error {
+    constructor(
+      message: string,
+      public status: number,
+    ) {
+      super(message);
+      this.name = 'ApiError';
+    }
+  },
+}));
+
+const supervisorUser = {
+  id: 'supervisor-1',
+  email: 'supervisor@example.com',
+  name: 'Supervisor User',
+  role: 'supervisor',
+};
+
+const teamTemplateData = {
+  data: [
+    {
+      employeeId: 'emp-1',
+      employeeName: 'Alice Johnson',
+      employeeEmail: 'alice@example.com',
+      assignments: [
+        {
+          id: 'assign-1',
+          templateId: 'tpl-1',
+          templateName: 'Forklift Operator Onboarding',
+          status: 'in_progress',
+          dueDate: '2026-04-15T00:00:00.000Z',
+          completedAt: null,
+          totalRequirements: 4,
+          fulfilledRequirements: 2,
+          completionPercentage: 50,
+          isOverdue: false,
+          isAtRisk: true,
+        },
+        {
+          id: 'assign-2',
+          templateId: 'tpl-2',
+          templateName: 'Fire Safety Certification',
+          status: 'completed',
+          dueDate: '2026-03-01T00:00:00.000Z',
+          completedAt: '2026-02-28T00:00:00.000Z',
+          totalRequirements: 2,
+          fulfilledRequirements: 2,
+          completionPercentage: 100,
+          isOverdue: false,
+          isAtRisk: false,
+        },
+      ],
+      overallCompletionPercentage: 75,
+    },
+    {
+      employeeId: 'emp-2',
+      employeeName: 'Bob Williams',
+      employeeEmail: 'bob@example.com',
+      assignments: [
+        {
+          id: 'assign-3',
+          templateId: 'tpl-1',
+          templateName: 'Forklift Operator Onboarding',
+          status: 'in_progress',
+          dueDate: '2026-02-01T00:00:00.000Z',
+          completedAt: null,
+          totalRequirements: 4,
+          fulfilledRequirements: 1,
+          completionPercentage: 25,
+          isOverdue: true,
+          isAtRisk: false,
+        },
+      ],
+      overallCompletionPercentage: 25,
+    },
+  ],
+  total: 2,
+  page: 1,
+  limit: 200,
+};
+
+function mockApi(options?: { failLoad?: boolean; forbidden?: boolean; emptyData?: boolean }) {
+  return import('../../api/client').then(({ api, ApiError: MockApiError }) => {
+    vi.mocked(api.get).mockImplementation((path: string) => {
+      if (path === '/v1/platform/feature-flags') {
+        return Promise.resolve({ 'compliance.templates': true });
+      }
+
+      if (path.startsWith('/templates/team')) {
+        if (options?.failLoad) {
+          return Promise.reject(new Error('Server error'));
+        }
+
+        if (options?.forbidden) {
+          return Promise.reject(new MockApiError('Forbidden', 403));
+        }
+
+        if (options?.emptyData) {
+          return Promise.resolve({ data: [], total: 0, page: 1, limit: 200 });
+        }
+
+        return Promise.resolve(teamTemplateData);
+      }
+
+      return Promise.reject(new Error(`Unexpected GET: ${path}`));
+    });
+  });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={['/team/templates']}>
+      <AuthProvider>
+        <FeatureFlagsProvider>{children}</FeatureFlagsProvider>
+      </AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderTeamTemplates() {
+  localStorage.setItem('user', JSON.stringify(supervisorUser));
+  localStorage.setItem('token', 'fake-token');
+
+  return render(
+    <Wrapper>
+      <Routes>
+        <Route path="/team/templates" element={<TeamTemplatesPage />} />
+      </Routes>
+    </Wrapper>,
+  );
+}
+
+describe('TeamTemplatesPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders loading state then team data', async () => {
+    await mockApi();
+    renderTeamTemplates();
+
+    expect(screen.getByText(/loading team templates/i)).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: /team templates/i })).toBeInTheDocument();
+  });
+
+  it('displays summary statistics', async () => {
+    await mockApi();
+    renderTeamTemplates();
+
+    const summaryGrid = await screen.findByLabelText(/team template summary/i);
+    expect(summaryGrid).toBeInTheDocument();
+    expect(screen.getByText('Employees')).toBeInTheDocument();
+    expect(screen.getByText('Assignments')).toBeInTheDocument();
+  });
+
+  it('displays employee names and template names in table', async () => {
+    await mockApi();
+    renderTeamTemplates();
+
+    const table = await screen.findByRole('table', { name: /team template assignments/i });
+    expect(table).toBeInTheDocument();
+    expect(screen.getAllByText('Alice Johnson').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Bob Williams').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Forklift Operator Onboarding').length).toBeGreaterThan(0);
+    // "Fire Safety Certification" appears in both table and filter dropdown
+    expect(screen.getAllByText('Fire Safety Certification').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows status badges (completed, overdue, at risk)', async () => {
+    await mockApi();
+    renderTeamTemplates();
+
+    await screen.findByRole('table', { name: /team template assignments/i });
+    // These labels appear both as summary stat labels and as table badges
+    expect(screen.getAllByText('Completed').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('Overdue').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('At Risk').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows progress information per assignment', async () => {
+    await mockApi();
+    renderTeamTemplates();
+
+    await screen.findByRole('table', { name: /team template assignments/i });
+    expect(screen.getByText('2/4')).toBeInTheDocument(); // Alice's forklift
+    expect(screen.getByText('2/2')).toBeInTheDocument(); // Alice's fire safety
+    expect(screen.getByText('1/4')).toBeInTheDocument(); // Bob's forklift
+  });
+
+  it('allows searching by employee name', async () => {
+    await mockApi();
+    const user = userEvent.setup();
+    renderTeamTemplates();
+
+    await screen.findByRole('table', { name: /team template assignments/i });
+    const searchInput = screen.getByPlaceholderText(/search by employee or template/i);
+    await user.type(searchInput, 'bob');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Alice Johnson')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Bob Williams')).toBeInTheDocument();
+  });
+
+  it('allows filtering by status', async () => {
+    await mockApi();
+    const user = userEvent.setup();
+    renderTeamTemplates();
+
+    await screen.findByRole('table', { name: /team template assignments/i });
+    const statusSelect = screen.getByLabelText(/status filter/i);
+    await user.selectOptions(statusSelect, 'completed');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Bob Williams')).not.toBeInTheDocument();
+    });
+    expect(screen.getAllByText('Fire Safety Certification').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('allows filtering by template', async () => {
+    await mockApi();
+    const user = userEvent.setup();
+    renderTeamTemplates();
+
+    await screen.findByRole('table', { name: /team template assignments/i });
+    const templateSelect = screen.getByLabelText(/template filter/i);
+    await user.selectOptions(templateSelect, 'Fire Safety Certification');
+
+    await waitFor(() => {
+      expect(screen.queryByText('Bob Williams')).not.toBeInTheDocument();
+    });
+    expect(screen.getAllByText('Alice Johnson').length).toBeGreaterThan(0);
+  });
+
+  it('shows empty state when no assignments match filters', async () => {
+    await mockApi();
+    const user = userEvent.setup();
+    renderTeamTemplates();
+
+    await screen.findByRole('table', { name: /team template assignments/i });
+    const searchInput = screen.getByPlaceholderText(/search by employee or template/i);
+    await user.type(searchInput, 'nonexistent');
+
+    await waitFor(() => {
+      expect(screen.getByText(/no assignments match/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state when data fails to load', async () => {
+    await mockApi({ failLoad: true });
+    renderTeamTemplates();
+
+    await waitFor(() => {
+      expect(screen.getByText(/server error/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows permission error for forbidden access', async () => {
+    await mockApi({ forbidden: true });
+    renderTeamTemplates();
+
+    await waitFor(() => {
+      expect(screen.getByText(/limited to supervisors/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty summary when no data', async () => {
+    await mockApi({ emptyData: true });
+    renderTeamTemplates();
+
+    await waitFor(() => {
+      expect(screen.getByText(/no assignments match/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders breadcrumbs with navigation links', async () => {
+    await mockApi();
+    renderTeamTemplates();
+
+    await screen.findByRole('table', { name: /team template assignments/i });
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^team$/i })).toBeInTheDocument();
+  });
+
+  it('has a link to Template Library', async () => {
+    await mockApi();
+    renderTeamTemplates();
+
+    await screen.findByRole('table', { name: /team template assignments/i });
+    expect(screen.getByRole('link', { name: /template library/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/__tests__/TemplateAssignPage.test.tsx
+++ b/apps/web/src/pages/__tests__/TemplateAssignPage.test.tsx
@@ -1,0 +1,272 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from '../../contexts/AuthContext';
+import { FeatureFlagsProvider } from '../../hooks/useFeatureFlags';
+import TemplateAssignPage from '../TemplateAssignPage';
+
+vi.mock('../../api/client', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+  ApiError: class extends Error {
+    constructor(
+      message: string,
+      public status: number,
+    ) {
+      super(message);
+      this.name = 'ApiError';
+    }
+  },
+}));
+
+const supervisorUser = {
+  id: 'supervisor-1',
+  email: 'supervisor@example.com',
+  name: 'Supervisor User',
+  role: 'supervisor',
+};
+
+const publishedTemplate = {
+  id: 'tpl-1',
+  name: 'Forklift Operator Onboarding',
+  description: 'Full onboarding template for forklift operators.',
+  category: 'Safety',
+  status: 'published',
+  version: 2,
+  previousVersion: null,
+  createdBy: 'admin-1',
+  updatedBy: null,
+  standardId: null,
+  createdAt: '2026-03-10T00:00:00.000Z',
+  updatedAt: '2026-03-10T00:00:00.000Z',
+  publishedAt: '2026-03-12T00:00:00.000Z',
+  archivedAt: null,
+  requirements: [
+    {
+      id: 'req-1',
+      templateId: 'tpl-1',
+      name: 'OSHA 10-Hour Card',
+      description: 'Upload your OSHA card.',
+      attestationLevels: ['upload'],
+      proofType: 'certification',
+      proofSubType: null,
+      threshold: null,
+      thresholdUnit: null,
+      rollingWindowDays: null,
+      universalCategory: null,
+      qualificationType: null,
+      medicalTestType: null,
+      standardReqId: null,
+      validityDays: 365,
+      renewalWarningDays: 30,
+      sortOrder: 0,
+      isRequired: true,
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    },
+  ],
+};
+
+const employeesList = {
+  data: [
+    {
+      id: 'emp-1',
+      employeeNumber: 'E001',
+      firstName: 'Alice',
+      lastName: 'Johnson',
+      email: 'alice@example.com',
+      role: 'employee',
+      departmentId: 'Operations',
+      isActive: true,
+    },
+    {
+      id: 'emp-2',
+      employeeNumber: 'E002',
+      firstName: 'Bob',
+      lastName: 'Williams',
+      email: 'bob@example.com',
+      role: 'employee',
+      departmentId: 'Warehouse',
+      isActive: true,
+    },
+    {
+      id: 'emp-3',
+      employeeNumber: 'E003',
+      firstName: 'Charlie',
+      lastName: 'Brown',
+      email: 'charlie@example.com',
+      role: 'employee',
+      departmentId: 'HR',
+      isActive: false,
+    },
+  ],
+  total: 3,
+  page: 1,
+  limit: 50,
+};
+
+function mockApi(options?: { failLoad?: boolean; failAssign?: boolean }) {
+  return import('../../api/client').then(({ api }) => {
+    vi.mocked(api.get).mockImplementation((path: string) => {
+      if (path === '/v1/platform/feature-flags') {
+        return Promise.resolve({ 'compliance.templates': true });
+      }
+
+      if (path === '/templates/tpl-1') {
+        if (options?.failLoad) {
+          return Promise.reject(new Error('Template not found'));
+        }
+        return Promise.resolve(publishedTemplate);
+      }
+
+      if (path === '/employees') {
+        return Promise.resolve(employeesList);
+      }
+
+      return Promise.reject(new Error(`Unexpected GET: ${path}`));
+    });
+
+    vi.mocked(api.post).mockImplementation((path: string) => {
+      if (path === '/templates/tpl-1/assign') {
+        if (options?.failAssign) {
+          return Promise.reject(new Error('Assignment failed'));
+        }
+        return Promise.resolve({ assignments: [], created: 2, skipped: 0 });
+      }
+
+      return Promise.reject(new Error(`Unexpected POST: ${path}`));
+    });
+  });
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={['/templates/tpl-1/assign']}>
+      <AuthProvider>
+        <FeatureFlagsProvider>{children}</FeatureFlagsProvider>
+      </AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderAssign() {
+  localStorage.setItem('user', JSON.stringify(supervisorUser));
+  localStorage.setItem('token', 'fake-token');
+
+  return render(
+    <Wrapper>
+      <Routes>
+        <Route path="/templates/:id/assign" element={<TemplateAssignPage />} />
+      </Routes>
+    </Wrapper>,
+  );
+}
+
+describe('TemplateAssignPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders loading state then assignment form', async () => {
+    await mockApi();
+    renderAssign();
+
+    expect(screen.getByText(/loading template assignment/i)).toBeInTheDocument();
+    expect(await screen.findByText(/choose employees/i)).toBeInTheDocument();
+  });
+
+  it('displays employee list with names and status badges', async () => {
+    await mockApi();
+    renderAssign();
+
+    expect(await screen.findByText('Alice Johnson')).toBeInTheDocument();
+    expect(screen.getByText('Bob Williams')).toBeInTheDocument();
+    expect(screen.getByText('Charlie Brown')).toBeInTheDocument();
+    expect(screen.getByText('Operations')).toBeInTheDocument();
+    expect(screen.getByText('Warehouse')).toBeInTheDocument();
+  });
+
+  it('shows assignment summary panel with template info', async () => {
+    await mockApi();
+    renderAssign();
+
+    expect(await screen.findByText(/assignment summary/i)).toBeInTheDocument();
+    // Template name appears in breadcrumb + sidebar
+    expect(screen.getAllByText('Forklift Operator Onboarding').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('No deadline')).toBeInTheDocument();
+  });
+
+  it('allows searching employees by name', async () => {
+    await mockApi();
+    const user = userEvent.setup();
+    renderAssign();
+
+    await screen.findByText('Alice Johnson');
+    const searchInput = screen.getByPlaceholderText(/search by name/i);
+    await user.type(searchInput, 'alice');
+
+    expect(screen.getByText('Alice Johnson')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Williams')).not.toBeInTheDocument();
+  });
+
+  it('selects employees with checkboxes', async () => {
+    await mockApi();
+    const user = userEvent.setup();
+    renderAssign();
+
+    await screen.findByText('Alice Johnson');
+    const checkboxes = screen.getAllByRole('checkbox');
+    await user.click(checkboxes[0]);
+
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+  });
+
+  it('shows "Select filtered active" and "Clear selection" buttons', async () => {
+    await mockApi();
+    renderAssign();
+
+    await screen.findByText('Alice Johnson');
+    expect(screen.getByRole('button', { name: /select filtered active/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /clear selection/i })).toBeInTheDocument();
+  });
+
+  it('shows due date picker', async () => {
+    await mockApi();
+    renderAssign();
+
+    await screen.findByText('Alice Johnson');
+    const dateInput = screen.getByLabelText(/^due date$/i);
+    expect(dateInput).toBeInTheDocument();
+  });
+
+  it('shows error state when loading fails', async () => {
+    await mockApi({ failLoad: true });
+    renderAssign();
+
+    await waitFor(() => {
+      expect(screen.getByText(/template not found/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders breadcrumbs with navigation links', async () => {
+    await mockApi();
+    renderAssign();
+
+    await screen.findByText(/choose employees/i);
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Template Library')).toBeInTheDocument();
+  });
+
+  it('has confirm assignment button', async () => {
+    await mockApi();
+    renderAssign();
+
+    await screen.findByText('Alice Johnson');
+    expect(screen.getByRole('button', { name: /confirm assignment/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/__tests__/TemplateEditorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/TemplateEditorPage.test.tsx
@@ -1,0 +1,290 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from '../../contexts/AuthContext';
+import { FeatureFlagsProvider } from '../../hooks/useFeatureFlags';
+import TemplateEditorPage from '../TemplateEditorPage';
+
+vi.mock('../../api/client', () => ({
+  api: {
+    get: vi.fn(),
+    put: vi.fn(),
+    post: vi.fn(),
+    del: vi.fn(),
+  },
+  ApiError: class extends Error {
+    constructor(
+      message: string,
+      public status: number,
+    ) {
+      super(message);
+      this.name = 'ApiError';
+    }
+  },
+}));
+
+const managerUser = {
+  id: 'manager-1',
+  email: 'manager@example.com',
+  name: 'Manager User',
+  role: 'manager',
+};
+
+const draftTemplate: {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  status: string;
+  version: number;
+  previousVersion: string | null;
+  createdBy: string;
+  updatedBy: string | null;
+  standardId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  publishedAt: string | null;
+  archivedAt: string | null;
+  requirements: {
+    id: string;
+    templateId: string;
+    name: string;
+    description: string;
+    attestationLevels: string[];
+    proofType: string;
+    proofSubType: string | null;
+    threshold: number | null;
+    thresholdUnit: string | null;
+    rollingWindowDays: number | null;
+    universalCategory: string | null;
+    qualificationType: string | null;
+    medicalTestType: string | null;
+    standardReqId: string | null;
+    validityDays: number | null;
+    renewalWarningDays: number | null;
+    sortOrder: number;
+    isRequired: boolean;
+    createdAt: string;
+    updatedAt: string;
+  }[];
+} = {
+  id: 'tpl-draft',
+  name: 'Safety Induction',
+  description: 'Onboarding safety procedures.',
+  category: 'Safety',
+  status: 'draft',
+  version: 1,
+  previousVersion: null,
+  createdBy: 'admin-1',
+  updatedBy: null,
+  standardId: null,
+  createdAt: '2026-03-10T00:00:00.000Z',
+  updatedAt: '2026-03-10T00:00:00.000Z',
+  publishedAt: null,
+  archivedAt: null,
+  requirements: [
+    {
+      id: 'req-1',
+      templateId: 'tpl-draft',
+      name: 'Fire Safety Training',
+      description: 'Complete fire safety course.',
+      attestationLevels: ['upload', 'validated'],
+      proofType: 'training',
+      proofSubType: null,
+      threshold: null,
+      thresholdUnit: null,
+      rollingWindowDays: null,
+      universalCategory: null,
+      qualificationType: null,
+      medicalTestType: null,
+      standardReqId: null,
+      validityDays: null,
+      renewalWarningDays: null,
+      sortOrder: 0,
+      isRequired: true,
+      createdAt: '2026-03-10T00:00:00.000Z',
+      updatedAt: '2026-03-10T00:00:00.000Z',
+    },
+  ],
+};
+
+const publishedTemplate = {
+  ...draftTemplate,
+  id: 'tpl-published',
+  status: 'published',
+  publishedAt: '2026-03-12T00:00:00.000Z' as string | null,
+  requirements: draftTemplate.requirements.map((r) => ({
+    ...r,
+    templateId: 'tpl-published',
+  })),
+};
+
+function mockApi(options?: { template?: typeof draftTemplate; failLoad?: boolean }) {
+  return import('../../api/client').then(({ api }) => {
+    const template = options?.template ?? draftTemplate;
+    const templateId = template.id;
+
+    vi.mocked(api.get).mockImplementation((path: string) => {
+      if (path === '/v1/platform/feature-flags') {
+        return Promise.resolve({ 'compliance.templates': true });
+      }
+
+      if (path === `/templates/${templateId}`) {
+        if (options?.failLoad) {
+          return Promise.reject(new Error('Failed to load template'));
+        }
+        return Promise.resolve(template);
+      }
+
+      return Promise.reject(new Error(`Unexpected GET: ${path}`));
+    });
+
+    vi.mocked(api.put).mockImplementation((path: string) => {
+      if (path === `/templates/${templateId}`) {
+        return Promise.resolve(template);
+      }
+
+      if (path.includes('/requirements/reorder')) {
+        return Promise.resolve(template.requirements);
+      }
+
+      if (path.includes('/requirements/')) {
+        return Promise.resolve(template.requirements[0]);
+      }
+
+      return Promise.reject(new Error(`Unexpected PUT: ${path}`));
+    });
+
+    vi.mocked(api.post).mockImplementation((path: string) => {
+      if (path.includes('/requirements')) {
+        return Promise.resolve({ ...template.requirements[0], id: 'req-new' });
+      }
+
+      return Promise.reject(new Error(`Unexpected POST: ${path}`));
+    });
+
+    vi.mocked(api.del).mockImplementation(() => Promise.resolve(undefined as void));
+  });
+}
+
+function Wrapper({
+  children,
+  initialPath = '/templates/tpl-draft/edit',
+}: {
+  children: ReactNode;
+  initialPath?: string;
+}) {
+  return (
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AuthProvider>
+        <FeatureFlagsProvider>{children}</FeatureFlagsProvider>
+      </AuthProvider>
+    </MemoryRouter>
+  );
+}
+
+function renderEditor(options?: { template?: typeof draftTemplate; initialPath?: string }) {
+  const template = options?.template ?? draftTemplate;
+
+  localStorage.setItem('user', JSON.stringify(managerUser));
+  localStorage.setItem('token', 'fake-token');
+
+  return render(
+    <Wrapper initialPath={options?.initialPath ?? `/templates/${template.id}/edit`}>
+      <Routes>
+        <Route path="/templates/:id/edit" element={<TemplateEditorPage />} />
+      </Routes>
+    </Wrapper>,
+  );
+}
+
+describe('TemplateEditorPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders loading state then template form', async () => {
+    await mockApi();
+    renderEditor();
+
+    expect(screen.getByText(/loading template editor/i)).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('Safety Induction')).toBeInTheDocument();
+  });
+
+  it('displays template metadata fields', async () => {
+    await mockApi();
+    renderEditor();
+
+    expect(await screen.findByDisplayValue('Safety Induction')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Safety')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Onboarding safety procedures.')).toBeInTheDocument();
+  });
+
+  it('shows requirements list with name and attestation levels', async () => {
+    await mockApi();
+    renderEditor();
+
+    expect(await screen.findByDisplayValue('Fire Safety Training')).toBeInTheDocument();
+    expect(screen.getByText('1 requirements')).toBeInTheDocument();
+  });
+
+  it('enables adding a new requirement', async () => {
+    await mockApi();
+    const user = userEvent.setup();
+    renderEditor();
+
+    await screen.findByDisplayValue('Fire Safety Training');
+    const addButton = screen.getByRole('button', { name: /add requirement/i });
+    await user.click(addButton);
+
+    expect(screen.getByText('2 requirements')).toBeInTheDocument();
+  });
+
+  it('shows read-only notice for published templates', async () => {
+    await mockApi({ template: publishedTemplate });
+    renderEditor({ template: publishedTemplate });
+
+    await screen.findByDisplayValue('Safety Induction');
+    expect(screen.getByText(/published and archived templates are read-only/i)).toBeInTheDocument();
+  });
+
+  it('shows error state when template fails to load', async () => {
+    await mockApi({ failLoad: true });
+    renderEditor();
+
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load template/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows proof type dropdown with correct options', async () => {
+    await mockApi();
+    renderEditor();
+
+    await screen.findByDisplayValue('Safety Induction');
+    const proofTypeSelect = screen.getByRole('combobox', { name: /proof type/i });
+    expect(proofTypeSelect).toBeInTheDocument();
+    expect(proofTypeSelect).toHaveValue('training');
+  });
+
+  it('renders breadcrumbs with navigation links', async () => {
+    await mockApi();
+    renderEditor();
+
+    await screen.findByDisplayValue('Safety Induction');
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Template Library')).toBeInTheDocument();
+  });
+
+  it('has save and cancel buttons', async () => {
+    await mockApi();
+    renderEditor();
+
+    await screen.findByDisplayValue('Safety Induction');
+    expect(screen.getAllByRole('button', { name: /save template/i }).length).toBeGreaterThan(0);
+    expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/styles/managed-pages.css
+++ b/apps/web/src/styles/managed-pages.css
@@ -115,6 +115,36 @@
   gap: 0.25rem;
 }
 
+.managed-page__table-wrapper {
+  overflow-x: auto;
+}
+
+.managed-page__table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9375rem;
+}
+
+.managed-page__table th,
+.managed-page__table td {
+  padding: 0.75rem 0.875rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.managed-page__table th {
+  font-weight: 600;
+  font-size: 0.8125rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--color-text-secondary);
+  background: var(--color-gray-50);
+}
+
+.managed-page__table tbody tr:hover {
+  background: var(--color-gray-50);
+}
+
 .managed-page__table-link {
   color: var(--color-primary);
   text-decoration: none;

--- a/apps/web/src/styles/template-screens.css
+++ b/apps/web/src/styles/template-screens.css
@@ -157,6 +157,29 @@
   align-items: center;
 }
 
+/* Progress bar for team template view */
+.template-screen__progress-cell {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 120px;
+}
+
+.template-screen__progress-bar {
+  flex: 1;
+  height: 8px;
+  background: var(--color-gray-100);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.template-screen__progress-fill {
+  height: 100%;
+  background: var(--color-success);
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
 @media (max-width: 768px) {
   .template-screen__evidence-item {
     flex-direction: column;


### PR DESCRIPTION
## Summary

Delivers three template management pages for issues #15, #16, #17:

### Pages

- **Template Editor** (/templates/:id/edit) — Full form to edit template name, description, proof type, and requirements list with add/remove/reorder. Manager+ role required. *(Already built in PR #61, now tested)*
- **Template Assign** (/templates/:id/assign) — Employee multi-select with search, due date picker, bulk assignment with sticky summary panel. Supervisor+ role required. *(Already built in PR #61, now tested)*
- **Team Templates** (/team/templates) — **NEW** supervisor data table view with employee name, template, status badges (Completed/In Progress/Overdue/At Risk), progress bars, due dates. Includes search, status filter, and template filter.

### Changes

| File | Change |
|------|--------|
| \TeamTemplatesPage.tsx\ | New page — team assignment overview with filters, table, progress bars |
| \App.tsx\ | Added \/team/templates\ route (supervisor+, feature-gated) |
| \Layout.tsx\ | Added Team Templates sidebar nav link for supervisors |
| \DashboardPage.tsx\ | Updated Team Templates quick action to point to \/team/templates\ |
| \managed-pages.css\ | Added table styles (\.managed-page__table\) |
| \	emplate-screens.css\ | Added progress bar styles |
| 3 test files | 33 new tests covering all three pages |

### Test Results

All **91 web tests passing** (33 new + 58 existing). No regressions.

Closes #15, closes #16, closes #17