### PR TITLE
feat(web): Manager analytics dashboard (#22)

### DIFF
--- a/.squad/agents/kima/history.md
+++ b/.squad/agents/kima/history.md
@@ -93,6 +93,7 @@
 - 2026-03-16: My section pages deliver self-service UI with API response shape normalization in-component. All pages consume `AuthContext.user.id` for personalized queries. Graceful degradation for pending 404/501 endpoints ("Coming Soon" UX).
 - 2026-03-16: Team supervision pages reuse My-section visual system plus PageShell tabs/breadcrumbs, keep employee fetch + record fetch separate for resilient loading/error states, and use inline forms for qualification/medical/document actions instead of introducing a modal pattern.
 - 2026-03-18: ReviewQueue enriches minimal queue payload with document + employee lookups and derives a display-only priority until the backend exposes one. Inline management forms for team supervision pages (card-based vs modal system) keep behavior consistent with My section, reduce implementation risk, and stay responsive.
+- 2026-03-19: Built ManagerDashboardPage at /dashboard/manager (SUPERVISOR+) with 4 reusable dashboard components (StatCard, ProgressBar, ComplianceStatusBadge, ExpiryWarningList). Uses Promise.allSettled for resilient multi-endpoint fetching (/employees, /assignments/team, /qualifications, /medical) with partial-failure UX. ExpiryWarningList buckets items into 30/60/90-day urgency tiers. All 145 web tests passing including 12 new page tests and 27 new component tests.
 
 ## 📌 Team Update (2026-03-16T073200Z — Freamon's Backlog Decomposition)
 

--- a/.squad/decisions/inbox/kima-analytics-dashboard.md
+++ b/.squad/decisions/inbox/kima-analytics-dashboard.md
@@ -1,0 +1,34 @@
+# Decision: Manager Analytics Dashboard Component Architecture
+
+**Date:** 2026-03-19
+**Author:** Kima (Frontend Dev)
+**Issue:** #22
+**Status:** Implemented
+
+## Context
+
+Managers need a single-page analytics view showing team compliance status, template assignment progress, and expiring items. This required deciding between embedding analytics into the existing Dashboard or creating a separate page.
+
+## Decision
+
+Created a dedicated `/dashboard/manager` route with SUPERVISOR+ RBAC gating, separate from the role-adaptive home dashboard at `/`. This keeps the home dashboard lightweight (personal workspace) and gives managers a purpose-built analytics view with higher information density.
+
+## Reusable Components
+
+Introduced 4 new reusable dashboard components under `components/dashboard/`:
+- **StatCard** — Labeled value card with tone (healthy/warning/critical/neutral)
+- **ProgressBar** — Accessible progress bar with label, fraction, and ARIA attributes
+- **ComplianceStatusBadge** — Compliance status pill (compliant/at_risk/non_compliant)
+- **ExpiryWarningList** — 30/60/90-day bucketed expiry warning panel
+
+These are not dashboard-specific — they can be reused on any page that needs compliance visualization.
+
+## Data Fetching
+
+Uses `Promise.allSettled` across 4 endpoints with partial-failure UX. If some endpoints fail, available data is still shown with a notice. This is consistent with the existing DashboardPage pattern.
+
+## Impact
+
+- Layout nav gains "Analytics" link for supervisor+ roles
+- No breaking changes to existing pages or tests
+- All 145 web tests passing

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,6 +17,7 @@ import TeamTemplatesPage from './pages/TeamTemplatesPage';
 import TemplatesFeatureUnavailablePage from './pages/TemplatesFeatureUnavailablePage';
 import FulfillmentReviewQueuePage from './pages/FulfillmentReviewQueuePage';
 import FulfillmentReviewDetailPage from './pages/FulfillmentReviewDetailPage';
+import ManagerDashboardPage from './pages/ManagerDashboardPage';
 import {
   MyDocumentsPage,
   MyHoursPage,
@@ -271,6 +272,14 @@ function App() {
               <FeatureGate flag="compliance.templates" fallback={<TemplatesFeatureUnavailablePage />}>
                 <FulfillmentReviewDetailPage />
               </FeatureGate>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/dashboard/manager"
+          element={
+            <ProtectedRoute minRole="supervisor">
+              <ManagerDashboardPage />
             </ProtectedRoute>
           }
         />

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -15,6 +15,7 @@ export default function Layout({ children }: LayoutProps) {
   const canReviewDocuments = hasMinimumRole(user?.role, 'manager');
 
   const navItems = [
+    canAccessTeam ? { path: '/dashboard/manager', label: 'Analytics' } : null,
     canAccessTeam ? { path: '/team', label: 'Team' } : null,
     canAccessTeam ? { path: '/team/templates', label: 'Team Templates', flag: 'compliance.templates' } : null,
     canReviewDocuments ? { path: '/reviews', label: 'Document Review' } : null,

--- a/apps/web/src/components/dashboard/ComplianceStatusBadge.tsx
+++ b/apps/web/src/components/dashboard/ComplianceStatusBadge.tsx
@@ -1,0 +1,22 @@
+import type { ComplianceStatus } from '../../types/my-section';
+
+export interface ComplianceStatusBadgeProps {
+  status: ComplianceStatus;
+  label?: string;
+}
+
+const STATUS_CONFIG: Record<ComplianceStatus, { className: string; defaultLabel: string }> = {
+  compliant: { className: 'mgr-compliance-badge mgr-compliance-badge--compliant', defaultLabel: 'Compliant' },
+  at_risk: { className: 'mgr-compliance-badge mgr-compliance-badge--at-risk', defaultLabel: 'At Risk' },
+  non_compliant: { className: 'mgr-compliance-badge mgr-compliance-badge--non-compliant', defaultLabel: 'Non-Compliant' },
+};
+
+export default function ComplianceStatusBadge({ status, label }: ComplianceStatusBadgeProps) {
+  const config = STATUS_CONFIG[status] ?? STATUS_CONFIG.non_compliant;
+
+  return (
+    <span className={config.className} role="status">
+      {label ?? config.defaultLabel}
+    </span>
+  );
+}

--- a/apps/web/src/components/dashboard/ExpiryWarningList.tsx
+++ b/apps/web/src/components/dashboard/ExpiryWarningList.tsx
@@ -1,0 +1,103 @@
+import { getDaysUntil, formatDate } from '../../pages/pageHelpers';
+
+export interface ExpiryItem {
+  id: string;
+  name: string;
+  employeeName?: string;
+  type: 'qualification' | 'medical';
+  expiresAt: string;
+}
+
+export interface ExpiryWarningListProps {
+  items: ExpiryItem[];
+  title?: string;
+}
+
+type UrgencyBucket = '30' | '60' | '90';
+
+function getUrgencyClass(days: number): string {
+  if (days <= 0) return 'mgr-expiry-item mgr-expiry-item--overdue';
+  if (days <= 30) return 'mgr-expiry-item mgr-expiry-item--critical';
+  if (days <= 60) return 'mgr-expiry-item mgr-expiry-item--warning';
+  return 'mgr-expiry-item mgr-expiry-item--caution';
+}
+
+function getUrgencyLabel(days: number): string {
+  if (days <= 0) return 'Overdue';
+  if (days === 1) return '1 day left';
+  return `${days} days left`;
+}
+
+function bucketLabel(bucket: UrgencyBucket): string {
+  switch (bucket) {
+    case '30': return 'Due within 30 days';
+    case '60': return 'Due within 60 days';
+    case '90': return 'Due within 90 days';
+  }
+}
+
+export default function ExpiryWarningList({ items, title = 'Expiring Items' }: ExpiryWarningListProps) {
+  const expiryItems = items
+    .map((item) => ({ ...item, daysLeft: getDaysUntil(item.expiresAt) }))
+    .filter((item) => item.daysLeft <= 90)
+    .sort((a, b) => a.daysLeft - b.daysLeft);
+
+  const buckets: Record<UrgencyBucket, typeof expiryItems> = { '30': [], '60': [], '90': [] };
+  for (const item of expiryItems) {
+    if (item.daysLeft <= 30) buckets['30'].push(item);
+    else if (item.daysLeft <= 60) buckets['60'].push(item);
+    else buckets['90'].push(item);
+  }
+
+  if (expiryItems.length === 0) {
+    return (
+      <section className="mgr-expiry-panel" aria-labelledby="mgr-expiry-title">
+        <h3 id="mgr-expiry-title">{title}</h3>
+        <p className="mgr-expiry-empty">No items expiring within 90 days.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="mgr-expiry-panel" aria-labelledby="mgr-expiry-title">
+      <h3 id="mgr-expiry-title">{title}</h3>
+      <div className="mgr-expiry-summary">
+        <span className="mgr-expiry-summary__count mgr-expiry-summary__count--critical">
+          {buckets['30'].length} within 30d
+        </span>
+        <span className="mgr-expiry-summary__count mgr-expiry-summary__count--warning">
+          {buckets['60'].length} within 60d
+        </span>
+        <span className="mgr-expiry-summary__count mgr-expiry-summary__count--caution">
+          {buckets['90'].length} within 90d
+        </span>
+      </div>
+      {(['30', '60', '90'] as UrgencyBucket[]).map((bucket) =>
+        buckets[bucket].length > 0 ? (
+          <div key={bucket} className="mgr-expiry-bucket">
+            <h4 className="mgr-expiry-bucket__title">{bucketLabel(bucket)}</h4>
+            <ul className="mgr-expiry-list" role="list">
+              {buckets[bucket].map((item) => (
+                <li key={item.id} className={getUrgencyClass(item.daysLeft)}>
+                  <div className="mgr-expiry-item__info">
+                    <span className="mgr-expiry-item__name">{item.name}</span>
+                    {item.employeeName ? (
+                      <span className="mgr-expiry-item__employee">{item.employeeName}</span>
+                    ) : null}
+                    <span className="mgr-expiry-item__type">
+                      {item.type === 'qualification' ? 'Qualification' : 'Medical Clearance'}
+                    </span>
+                  </div>
+                  <div className="mgr-expiry-item__meta">
+                    <span className="mgr-expiry-item__date">Expires {formatDate(item.expiresAt)}</span>
+                    <span className="mgr-expiry-item__countdown">{getUrgencyLabel(item.daysLeft)}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null,
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/dashboard/ProgressBar.tsx
+++ b/apps/web/src/components/dashboard/ProgressBar.tsx
@@ -1,0 +1,35 @@
+export interface ProgressBarProps {
+  label: string;
+  current: number;
+  total: number;
+  unit?: string;
+}
+
+export default function ProgressBar({ label, current, total, unit = '' }: ProgressBarProps) {
+  const percentage = total > 0 ? Math.round((current / total) * 100) : 0;
+  const bounded = Math.max(0, Math.min(percentage, 100));
+
+  return (
+    <div className="mgr-progress" role="group" aria-label={label}>
+      <div className="mgr-progress__header">
+        <span className="mgr-progress__label">{label}</span>
+        <span className="mgr-progress__fraction">
+          {current}/{total}{unit ? ` ${unit}` : ''} ({bounded}%)
+        </span>
+      </div>
+      <div
+        className="mgr-progress__track"
+        role="progressbar"
+        aria-valuenow={bounded}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={`${label}: ${bounded}%`}
+      >
+        <span
+          className="mgr-progress__fill"
+          style={{ width: `${bounded}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/StatCard.tsx
+++ b/apps/web/src/components/dashboard/StatCard.tsx
@@ -1,0 +1,31 @@
+export type StatTone = 'healthy' | 'warning' | 'critical' | 'neutral';
+
+export interface StatCardProps {
+  label: string;
+  value: string | number;
+  subtitle?: string;
+  tone?: StatTone;
+}
+
+function getToneClass(tone: StatTone) {
+  switch (tone) {
+    case 'healthy':
+      return 'mgr-stat-card mgr-stat-card--healthy';
+    case 'warning':
+      return 'mgr-stat-card mgr-stat-card--warning';
+    case 'critical':
+      return 'mgr-stat-card mgr-stat-card--critical';
+    default:
+      return 'mgr-stat-card mgr-stat-card--neutral';
+  }
+}
+
+export default function StatCard({ label, value, subtitle, tone = 'neutral' }: StatCardProps) {
+  return (
+    <div className={getToneClass(tone)} role="group" aria-label={label}>
+      <span className="mgr-stat-card__label">{label}</span>
+      <strong className="mgr-stat-card__value">{value}</strong>
+      {subtitle ? <span className="mgr-stat-card__subtitle">{subtitle}</span> : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/__tests__/ComplianceStatusBadge.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/ComplianceStatusBadge.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ComplianceStatusBadge from '../ComplianceStatusBadge';
+
+describe('ComplianceStatusBadge', () => {
+  it('renders compliant badge with default label', () => {
+    render(<ComplianceStatusBadge status="compliant" />);
+
+    const badge = screen.getByRole('status');
+    expect(badge).toHaveTextContent('Compliant');
+    expect(badge.className).toContain('mgr-compliance-badge--compliant');
+  });
+
+  it('renders at_risk badge with default label', () => {
+    render(<ComplianceStatusBadge status="at_risk" />);
+
+    const badge = screen.getByRole('status');
+    expect(badge).toHaveTextContent('At Risk');
+    expect(badge.className).toContain('mgr-compliance-badge--at-risk');
+  });
+
+  it('renders non_compliant badge with default label', () => {
+    render(<ComplianceStatusBadge status="non_compliant" />);
+
+    const badge = screen.getByRole('status');
+    expect(badge).toHaveTextContent('Non-Compliant');
+    expect(badge.className).toContain('mgr-compliance-badge--non-compliant');
+  });
+
+  it('uses custom label when provided', () => {
+    render(<ComplianceStatusBadge status="compliant" label="All Clear" />);
+
+    expect(screen.getByRole('status')).toHaveTextContent('All Clear');
+  });
+});

--- a/apps/web/src/components/dashboard/__tests__/ExpiryWarningList.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/ExpiryWarningList.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import ExpiryWarningList from '../ExpiryWarningList';
+import type { ExpiryItem } from '../ExpiryWarningList';
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+function isoDaysFromNow(days: number) {
+  return new Date(Date.now() + days * DAY_IN_MS).toISOString();
+}
+
+const testItems: ExpiryItem[] = [
+  { id: 'q1', name: 'Ramp Safety', employeeName: 'Alice', type: 'qualification', expiresAt: isoDaysFromNow(10) },
+  { id: 'q2', name: 'Dangerous Goods', employeeName: 'Bob', type: 'qualification', expiresAt: isoDaysFromNow(45) },
+  { id: 'm1', name: 'Annual Physical', employeeName: 'Charlie', type: 'medical', expiresAt: isoDaysFromNow(80) },
+  { id: 'q3', name: 'Fire Safety', type: 'qualification', expiresAt: isoDaysFromNow(-5) },
+  { id: 'q4', name: 'Far Future Cert', type: 'qualification', expiresAt: isoDaysFromNow(120) },
+];
+
+function renderList(items = testItems) {
+  return render(
+    <BrowserRouter>
+      <ExpiryWarningList items={items} />
+    </BrowserRouter>,
+  );
+}
+
+describe('ExpiryWarningList', () => {
+  it('renders the title', () => {
+    renderList();
+
+    expect(screen.getByRole('heading', { name: /expiring items/i })).toBeInTheDocument();
+  });
+
+  it('renders custom title', () => {
+    render(
+      <BrowserRouter>
+        <ExpiryWarningList items={testItems} title="Watch List" />
+      </BrowserRouter>,
+    );
+
+    expect(screen.getByRole('heading', { name: /watch list/i })).toBeInTheDocument();
+  });
+
+  it('shows empty state when no items expire within 90 days', () => {
+    renderList([{ id: 'x', name: 'Far out', type: 'qualification', expiresAt: isoDaysFromNow(200) }]);
+
+    expect(screen.getByText(/no items expiring within 90 days/i)).toBeInTheDocument();
+  });
+
+  it('renders bucket summary counts', () => {
+    renderList();
+
+    expect(screen.getByText(/2 within 30d/)).toBeInTheDocument();
+    expect(screen.getByText(/1 within 60d/)).toBeInTheDocument();
+    expect(screen.getByText(/1 within 90d/)).toBeInTheDocument();
+  });
+
+  it('does not include items beyond 90 days', () => {
+    renderList();
+
+    expect(screen.queryByText('Far Future Cert')).not.toBeInTheDocument();
+  });
+
+  it('renders overdue items with Overdue label', () => {
+    renderList();
+
+    expect(screen.getByText('Fire Safety')).toBeInTheDocument();
+    expect(screen.getByText('Overdue')).toBeInTheDocument();
+  });
+
+  it('shows employee name when available', () => {
+    renderList();
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('shows item type labels', () => {
+    renderList();
+
+    expect(screen.getAllByText('Qualification').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Medical Clearance').length).toBeGreaterThan(0);
+  });
+
+  it('sorts items by urgency (earliest first)', () => {
+    renderList();
+
+    const lists = screen.getAllByRole('list');
+    const allItems = lists.flatMap((list) => within(list).queryAllByRole('listitem'));
+    const names = allItems.map((li) => li.textContent ?? '');
+
+    // Fire Safety (overdue) should appear before Ramp Safety (10d)
+    const fireSafetyIndex = names.findIndex((t) => t?.includes('Fire Safety'));
+    const rampSafetyIndex = names.findIndex((t) => t?.includes('Ramp Safety'));
+    expect(fireSafetyIndex).toBeLessThan(rampSafetyIndex);
+  });
+});

--- a/apps/web/src/components/dashboard/__tests__/ProgressBar.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/ProgressBar.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ProgressBar from '../ProgressBar';
+
+describe('ProgressBar', () => {
+  it('renders label and percentage', () => {
+    render(<ProgressBar label="Team Compliance" current={30} total={40} />);
+
+    expect(screen.getByText('Team Compliance')).toBeInTheDocument();
+    expect(screen.getByText(/30\/40.*75%/)).toBeInTheDocument();
+  });
+
+  it('renders with unit label', () => {
+    render(<ProgressBar label="Assignments" current={5} total={10} unit="tasks" />);
+
+    expect(screen.getByText(/5\/10 tasks.*50%/)).toBeInTheDocument();
+  });
+
+  it('shows 0% when total is 0', () => {
+    render(<ProgressBar label="Empty" current={0} total={0} />);
+
+    expect(screen.getByText(/0\/0.*0%/)).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('caps percentage at 100', () => {
+    render(<ProgressBar label="Over" current={15} total={10} />);
+
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+  });
+
+  it('sets correct aria attributes on progressbar', () => {
+    render(<ProgressBar label="Progress" current={7} total={10} />);
+
+    const bar = screen.getByRole('progressbar');
+    expect(bar).toHaveAttribute('aria-valuenow', '70');
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('renders the fill bar with correct width', () => {
+    const { container } = render(<ProgressBar label="Fill" current={3} total={4} />);
+
+    const fill = container.querySelector('.mgr-progress__fill');
+    expect(fill).not.toBeNull();
+    expect((fill as HTMLElement).style.width).toBe('75%');
+  });
+});

--- a/apps/web/src/components/dashboard/__tests__/StatCard.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/StatCard.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StatCard from '../StatCard';
+
+describe('StatCard', () => {
+  it('renders label and value', () => {
+    render(<StatCard label="Team Members" value={42} />);
+
+    expect(screen.getByText('Team Members')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('renders subtitle when provided', () => {
+    render(<StatCard label="Compliant" value={30} subtitle="71% of team" />);
+
+    expect(screen.getByText('71% of team')).toBeInTheDocument();
+  });
+
+  it('does not render subtitle when omitted', () => {
+    const { container } = render(<StatCard label="Total" value={10} />);
+
+    expect(container.querySelector('.mgr-stat-card__subtitle')).toBeNull();
+  });
+
+  it('applies healthy tone class', () => {
+    render(<StatCard label="Compliant" value={10} tone="healthy" />);
+
+    const card = screen.getByRole('group', { name: 'Compliant' });
+    expect(card.className).toContain('mgr-stat-card--healthy');
+  });
+
+  it('applies warning tone class', () => {
+    render(<StatCard label="At Risk" value={5} tone="warning" />);
+
+    const card = screen.getByRole('group', { name: 'At Risk' });
+    expect(card.className).toContain('mgr-stat-card--warning');
+  });
+
+  it('applies critical tone class', () => {
+    render(<StatCard label="Non-Compliant" value={3} tone="critical" />);
+
+    const card = screen.getByRole('group', { name: 'Non-Compliant' });
+    expect(card.className).toContain('mgr-stat-card--critical');
+  });
+
+  it('defaults to neutral tone', () => {
+    render(<StatCard label="Total" value={100} />);
+
+    const card = screen.getByRole('group', { name: 'Total' });
+    expect(card.className).toContain('mgr-stat-card--neutral');
+  });
+
+  it('accepts string values', () => {
+    render(<StatCard label="Score" value="95%" />);
+
+    expect(screen.getByText('95%')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/index.ts
+++ b/apps/web/src/components/dashboard/index.ts
@@ -1,0 +1,9 @@
+export { default as StatCard } from './StatCard';
+export { default as ProgressBar } from './ProgressBar';
+export { default as ComplianceStatusBadge } from './ComplianceStatusBadge';
+export { default as ExpiryWarningList } from './ExpiryWarningList';
+
+export type { StatCardProps, StatTone } from './StatCard';
+export type { ProgressBarProps } from './ProgressBar';
+export type { ComplianceStatusBadgeProps } from './ComplianceStatusBadge';
+export type { ExpiryWarningListProps, ExpiryItem } from './ExpiryWarningList';

--- a/apps/web/src/pages/ManagerDashboardPage.tsx
+++ b/apps/web/src/pages/ManagerDashboardPage.tsx
@@ -1,0 +1,336 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import PageShell from '../components/PageShell';
+import { StatCard, ProgressBar, ComplianceStatusBadge, ExpiryWarningList } from '../components/dashboard';
+import type { ExpiryItem } from '../components/dashboard';
+import { api } from '../api/client';
+import { useAuth } from '../contexts/AuthContext';
+import { normalizeKey, toArray } from './pageHelpers';
+import type {
+  ComplianceStatus,
+  EmployeeProfile,
+  Qualification,
+  MedicalRecord,
+  PaginatedResponse,
+  TemplateAssignmentRecord,
+} from '../types/my-section';
+import '../styles/manager-dashboard.css';
+
+interface TeamEmployee {
+  id: string;
+  name: string;
+  status: ComplianceStatus;
+}
+
+interface DashboardData {
+  employees: TeamEmployee[];
+  assignments: TemplateAssignmentRecord[];
+  expiryItems: ExpiryItem[];
+}
+
+type AssignmentsResponse = TemplateAssignmentRecord[] | PaginatedResponse<TemplateAssignmentRecord>;
+type QualificationsResponse = Qualification[] | PaginatedResponse<Qualification>;
+type MedicalResponse = MedicalRecord[] | PaginatedResponse<MedicalRecord>;
+type EmployeesResponse = EmployeeProfile[] | PaginatedResponse<EmployeeProfile>;
+
+function resolveComplianceStatus(status?: string | null): ComplianceStatus {
+  const key = normalizeKey(status);
+  if (key === 'compliant' || key === 'active') return 'compliant';
+  if (key === 'at_risk' || key === 'expiring_soon' || key === 'pending_review') return 'at_risk';
+  return 'non_compliant';
+}
+
+function resolveEmployeeName(e: EmployeeProfile): string {
+  return `${e.firstName ?? ''} ${e.lastName ?? ''}`.trim() || e.name || e.email;
+}
+
+export default function ManagerDashboardPage() {
+  const { user, loading: authLoading } = useAuth();
+  const [data, setData] = useState<DashboardData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (authLoading) return;
+
+    let ignore = false;
+
+    async function fetchData() {
+      if (!user) {
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      setError('');
+
+      const [empResult, assignResult, qualResult, medResult] = await Promise.allSettled([
+        api.get<EmployeesResponse>('/employees'),
+        api.get<AssignmentsResponse>('/assignments/team'),
+        api.get<QualificationsResponse>('/qualifications'),
+        api.get<MedicalResponse>('/medical'),
+      ]);
+
+      if (ignore) return;
+
+      const failCount = [empResult, assignResult, qualResult, medResult].filter(
+        (r) => r.status === 'rejected',
+      ).length;
+
+      if (failCount === 4) {
+        setError('Dashboard data is temporarily unavailable. Please try again later.');
+        setData(null);
+        setLoading(false);
+        return;
+      }
+
+      const employees: TeamEmployee[] =
+        empResult.status === 'fulfilled'
+          ? toArray(empResult.value).map((e) => ({
+              id: e.id,
+              name: resolveEmployeeName(e),
+              status: resolveComplianceStatus(e.overallStatus),
+            }))
+          : [];
+
+      const assignments: TemplateAssignmentRecord[] =
+        assignResult.status === 'fulfilled' ? toArray(assignResult.value) : [];
+
+      const employeeMap = new Map<string, string>();
+      if (empResult.status === 'fulfilled') {
+        toArray(empResult.value).forEach((e) => employeeMap.set(e.id, resolveEmployeeName(e)));
+      }
+
+      const expiryItems: ExpiryItem[] = [];
+
+      if (qualResult.status === 'fulfilled') {
+        toArray(qualResult.value).forEach((q) => {
+          const expiresAt = q.expiresAt ?? q.expirationDate;
+          if (expiresAt) {
+            expiryItems.push({
+              id: q.id,
+              name: q.certificationName ?? q.name ?? q.standard?.name ?? 'Qualification',
+              employeeName: q.employeeId ? employeeMap.get(q.employeeId) : undefined,
+              type: 'qualification',
+              expiresAt,
+            });
+          }
+        });
+      }
+
+      if (medResult.status === 'fulfilled') {
+        toArray(medResult.value).forEach((m) => {
+          const expiresAt = m.validTo ?? m.expirationDate;
+          if (expiresAt) {
+            expiryItems.push({
+              id: m.id,
+              name: m.clearanceType,
+              employeeName: m.employeeId ? employeeMap.get(m.employeeId) : undefined,
+              type: 'medical',
+              expiresAt,
+            });
+          }
+        });
+      }
+
+      if (failCount > 0) {
+        setError('Some dashboard sections could not load. Showing available data.');
+      }
+
+      setData({ employees, assignments, expiryItems });
+      setLoading(false);
+    }
+
+    void fetchData();
+
+    return () => {
+      ignore = true;
+    };
+  }, [authLoading, user]);
+
+  const stats = useMemo(() => {
+    if (!data) return null;
+
+    const total = data.employees.length;
+    const compliant = data.employees.filter((e) => e.status === 'compliant').length;
+    const atRisk = data.employees.filter((e) => e.status === 'at_risk').length;
+    const nonCompliant = data.employees.filter((e) => e.status === 'non_compliant').length;
+    const compliantPct = total > 0 ? Math.round((compliant / total) * 100) : 0;
+
+    const totalAssignments = data.assignments.length;
+    const completedAssignments = data.assignments.filter((a) => a.completedAt !== null).length;
+
+    return {
+      total,
+      compliant,
+      atRisk,
+      nonCompliant,
+      compliantPct,
+      totalAssignments,
+      completedAssignments,
+    };
+  }, [data]);
+
+  if (authLoading || loading) {
+    return <div className="loading">Loading manager dashboard...</div>;
+  }
+
+  if (!user) {
+    return (
+      <PageShell title="Manager Dashboard" description="Dashboard is unavailable.">
+        <div className="dashboard-empty-state">We couldn&apos;t find a signed-in user session.</div>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell
+      title="Manager Dashboard"
+      description="Team compliance status, assignment progress, and expiring items at a glance."
+      breadcrumbs={[
+        { label: 'Dashboard', to: '/' },
+        { label: 'Manager Analytics' },
+      ]}
+      actions={
+        <span className="dashboard-role-badge">Analytics</span>
+      }
+    >
+      <div className="mgr-dashboard">
+        {error ? (
+          <div className="dashboard-inline-notice" role="status">
+            {error}
+          </div>
+        ) : null}
+
+        {stats ? (
+          <>
+            {/* Team Compliance Overview */}
+            <section className="mgr-dashboard__section" aria-labelledby="mgr-compliance-title">
+              <h2 id="mgr-compliance-title">Team Compliance</h2>
+              <div className="mgr-stat-grid">
+                <StatCard
+                  label="Team Members"
+                  value={stats.total}
+                  subtitle="Total headcount"
+                  tone="neutral"
+                />
+                <StatCard
+                  label="Compliant"
+                  value={stats.compliant}
+                  subtitle={`${stats.compliantPct}% of team`}
+                  tone="healthy"
+                />
+                <StatCard
+                  label="At Risk"
+                  value={stats.atRisk}
+                  subtitle="Expiring or pending"
+                  tone="warning"
+                />
+                <StatCard
+                  label="Non-Compliant"
+                  value={stats.nonCompliant}
+                  subtitle="Overdue or expired"
+                  tone="critical"
+                />
+              </div>
+              <div className="mgr-compliance-bar">
+                <ProgressBar
+                  label="Overall Team Compliance"
+                  current={stats.compliant}
+                  total={stats.total}
+                  unit="members"
+                />
+              </div>
+            </section>
+
+            {/* Compliance Breakdown */}
+            {stats.total > 0 ? (
+              <section className="mgr-dashboard__section" aria-labelledby="mgr-breakdown-title">
+                <h2 id="mgr-breakdown-title">Team Members by Status</h2>
+                <div className="mgr-employee-table">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th>Employee</th>
+                        <th>Status</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data!.employees.map((emp) => (
+                        <tr key={emp.id}>
+                          <td>
+                            <Link to={`/team/${emp.id}`} className="mgr-employee-link">
+                              {emp.name}
+                            </Link>
+                          </td>
+                          <td>
+                            <ComplianceStatusBadge status={emp.status} />
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            ) : null}
+
+            {/* Template Assignment Progress */}
+            <section className="mgr-dashboard__section" aria-labelledby="mgr-assignments-title">
+              <h2 id="mgr-assignments-title">Template Assignments</h2>
+              <div className="mgr-stat-grid mgr-stat-grid--compact">
+                <StatCard
+                  label="Total Assignments"
+                  value={stats.totalAssignments}
+                  tone="neutral"
+                />
+                <StatCard
+                  label="Completed"
+                  value={stats.completedAssignments}
+                  tone="healthy"
+                />
+                <StatCard
+                  label="In Progress"
+                  value={stats.totalAssignments - stats.completedAssignments}
+                  tone={stats.totalAssignments - stats.completedAssignments > 0 ? 'warning' : 'healthy'}
+                />
+              </div>
+              <div className="mgr-compliance-bar">
+                <ProgressBar
+                  label="Assignment Completion"
+                  current={stats.completedAssignments}
+                  total={stats.totalAssignments}
+                  unit="assignments"
+                />
+              </div>
+            </section>
+
+            {/* Expiring Items */}
+            <ExpiryWarningList
+              items={data!.expiryItems}
+              title="Expiring Qualifications & Clearances"
+            />
+
+            {/* Quick Actions */}
+            <section className="mgr-dashboard__section" aria-labelledby="mgr-actions-title">
+              <h2 id="mgr-actions-title">Quick Actions</h2>
+              <div className="mgr-quick-actions">
+                <Link to="/team/templates" className="mgr-quick-action">
+                  Assign Template
+                </Link>
+                <Link to="/reviews/templates" className="mgr-quick-action">
+                  Review Fulfillments
+                </Link>
+                <Link to="/team" className="mgr-quick-action">
+                  View Team Directory
+                </Link>
+                <Link to="/reviews" className="mgr-quick-action">
+                  Document Review Queue
+                </Link>
+              </div>
+            </section>
+          </>
+        ) : null}
+      </div>
+    </PageShell>
+  );
+}

--- a/apps/web/src/pages/__tests__/ManagerDashboardPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ManagerDashboardPage.test.tsx
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import ManagerDashboardPage from '../ManagerDashboardPage';
+import { AuthProvider } from '../../contexts/AuthContext';
+import { FeatureFlagsProvider } from '../../hooks/useFeatureFlags';
+
+vi.mock('../../api/client', () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+function isoDaysFromNow(days: number) {
+  return new Date(Date.now() + days * DAY_IN_MS).toISOString();
+}
+
+const supervisorUser = {
+  id: '3',
+  email: 'supervisor@example.com',
+  name: 'Supervisor User',
+  role: 'supervisor',
+};
+
+const managerUser = {
+  id: '4',
+  email: 'manager@example.com',
+  name: 'Manager User',
+  role: 'manager',
+};
+
+const mockEmployees = [
+  { id: 'e1', firstName: 'Alice', lastName: 'Smith', email: 'alice@example.com', role: 'employee', overallStatus: 'compliant' },
+  { id: 'e2', firstName: 'Bob', lastName: 'Jones', email: 'bob@example.com', role: 'employee', overallStatus: 'at_risk' },
+  { id: 'e3', firstName: 'Charlie', lastName: 'Brown', email: 'charlie@example.com', role: 'employee', overallStatus: 'non_compliant' },
+  { id: 'e4', firstName: 'Diana', lastName: 'Prince', email: 'diana@example.com', role: 'employee', overallStatus: 'compliant' },
+];
+
+const mockAssignments = [
+  { id: 'a1', templateId: 't1', templateVersion: 1, employeeId: 'e1', role: null, department: null, assignedBy: '3', dueDate: null, isActive: true, createdAt: '2026-01-01', updatedAt: '2026-01-01', completedAt: '2026-01-10', templateName: 'Safety Training', templateStatus: 'published' },
+  { id: 'a2', templateId: 't1', templateVersion: 1, employeeId: 'e2', role: null, department: null, assignedBy: '3', dueDate: null, isActive: true, createdAt: '2026-01-01', updatedAt: '2026-01-01', completedAt: null, templateName: 'Safety Training', templateStatus: 'published' },
+  { id: 'a3', templateId: 't2', templateVersion: 1, employeeId: 'e3', role: null, department: null, assignedBy: '3', dueDate: null, isActive: true, createdAt: '2026-01-05', updatedAt: '2026-01-05', completedAt: null, templateName: 'Fire Drill', templateStatus: 'published' },
+];
+
+const mockQualifications = [
+  { id: 'q1', employeeId: 'e1', certificationName: 'Ramp Safety', status: 'active', expiresAt: isoDaysFromNow(15) },
+  { id: 'q2', employeeId: 'e2', certificationName: 'Dangerous Goods', status: 'active', expiresAt: isoDaysFromNow(50) },
+  { id: 'q3', employeeId: 'e3', certificationName: 'Annual Refresher', status: 'expired', expiresAt: isoDaysFromNow(-10) },
+];
+
+const mockMedical = [
+  { id: 'm1', employeeId: 'e1', clearanceType: 'Annual Physical', status: 'cleared', validTo: isoDaysFromNow(25) },
+  { id: 'm2', employeeId: 'e4', clearanceType: 'Vision Test', status: 'cleared', validTo: isoDaysFromNow(70) },
+];
+
+const Wrapper = () => (
+  <BrowserRouter>
+    <AuthProvider>
+      <FeatureFlagsProvider>
+        <ManagerDashboardPage />
+      </FeatureFlagsProvider>
+    </AuthProvider>
+  </BrowserRouter>
+);
+
+function setUser(user = managerUser) {
+  localStorage.setItem('user', JSON.stringify(user));
+  localStorage.setItem('token', 'fake-token');
+}
+
+async function mockAllApis(overrides?: {
+  failEmployees?: boolean;
+  failAssignments?: boolean;
+  failQualifications?: boolean;
+  failMedical?: boolean;
+}) {
+  const { api } = await import('../../api/client');
+  const mockGet = vi.mocked(api.get);
+
+  mockGet.mockImplementation((path: string) => {
+    if (path === '/v1/platform/feature-flags') {
+      return Promise.resolve({ 'compliance.templates': true, 'records.hours-ui': true });
+    }
+    if (path === '/employees') {
+      return overrides?.failEmployees ? Promise.reject(new Error('fail')) : Promise.resolve(mockEmployees);
+    }
+    if (path === '/assignments/team') {
+      return overrides?.failAssignments ? Promise.reject(new Error('fail')) : Promise.resolve(mockAssignments);
+    }
+    if (path === '/qualifications') {
+      return overrides?.failQualifications ? Promise.reject(new Error('fail')) : Promise.resolve(mockQualifications);
+    }
+    if (path === '/medical') {
+      return overrides?.failMedical ? Promise.reject(new Error('fail')) : Promise.resolve(mockMedical);
+    }
+    return Promise.reject(new Error(`Unexpected: ${path}`));
+  });
+
+  return mockGet;
+}
+
+describe('ManagerDashboardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders the page title and breadcrumbs', async () => {
+    await mockAllApis();
+    setUser();
+    render(<Wrapper />);
+
+    expect(await screen.findByRole('heading', { name: /manager dashboard/i })).toBeInTheDocument();
+    expect(screen.getByText('Manager Analytics')).toBeInTheDocument();
+  });
+
+  it('shows loading state initially', async () => {
+    const { api } = await import('../../api/client');
+    vi.mocked(api.get).mockImplementation(() => new Promise(() => {}));
+    setUser();
+    render(<Wrapper />);
+
+    expect(screen.getByText(/loading manager dashboard/i)).toBeInTheDocument();
+  });
+
+  it('displays team compliance stat cards', async () => {
+    await mockAllApis();
+    setUser();
+    render(<Wrapper />);
+
+    expect(await screen.findByText('Team Members')).toBeInTheDocument();
+
+    const teamSection = screen.getByRole('heading', { name: /team compliance/i }).closest('section')!;
+
+    // 4 stat cards + 1 progress bar group = 5 groups
+    expect(within(teamSection).getByRole('group', { name: 'Team Members' })).toBeInTheDocument();
+    expect(within(teamSection).getByRole('group', { name: 'At Risk' })).toBeInTheDocument();
+
+    // Check the stat values: 4 total, 2 compliant, 1 at risk, 1 non-compliant
+    expect(within(teamSection).getByText('4')).toBeInTheDocument();
+    expect(within(teamSection).getByText('50% of team')).toBeInTheDocument();
+  });
+
+  it('shows team compliance percentage', async () => {
+    await mockAllApis();
+    setUser();
+    render(<Wrapper />);
+
+    expect(await screen.findByText(/50% of team/)).toBeInTheDocument();
+  });
+
+  it('shows template assignment stats', async () => {
+    await mockAllApis();
+    setUser();
+    render(<Wrapper />);
+
+    expect(await screen.findByRole('heading', { name: /template assignments/i })).toBeInTheDocument();
+    expect(screen.getByText('Total Assignments')).toBeInTheDocument();
+    // 3 total, 1 completed
+    const completedCard = screen.getByText('Completed').closest('[role="group"]');
+    expect(within(completedCard as HTMLElement).getByText('1')).toBeInTheDocument();
+  });
+
+  it('renders employee table with compliance badges', async () => {
+    await mockAllApis();
+    setUser();
+    render(<Wrapper />);
+
+    const tableSection = await screen.findByRole('heading', { name: /team members by status/i });
+    const section = tableSection.closest('section')!;
+
+    expect(within(section).getByRole('link', { name: 'Alice Smith' })).toBeInTheDocument();
+    expect(within(section).getByRole('link', { name: 'Bob Jones' })).toBeInTheDocument();
+    expect(within(section).getByRole('link', { name: 'Charlie Brown' })).toBeInTheDocument();
+    expect(within(section).getByRole('link', { name: 'Diana Prince' })).toBeInTheDocument();
+
+    const statusBadges = within(section).getAllByRole('status');
+    expect(statusBadges.length).toBe(4);
+  });
+
+  it('shows expiring items from qualifications and medical', async () => {
+    await mockAllApis();
+    setUser();
+    render(<Wrapper />);
+
+    expect(await screen.findByText('Ramp Safety')).toBeInTheDocument();
+    expect(screen.getByText('Annual Physical')).toBeInTheDocument();
+    expect(screen.getByText('Annual Refresher')).toBeInTheDocument();
+  });
+
+  it('renders quick action links', async () => {
+    await mockAllApis();
+    setUser();
+    render(<Wrapper />);
+
+    expect(await screen.findByRole('link', { name: /assign template/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /review fulfillments/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /view team directory/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /document review queue/i })).toBeInTheDocument();
+  });
+
+  it('shows error message when all APIs fail', async () => {
+    await mockAllApis({
+      failEmployees: true,
+      failAssignments: true,
+      failQualifications: true,
+      failMedical: true,
+    });
+    setUser();
+    render(<Wrapper />);
+
+    expect(await screen.findByText(/dashboard data is temporarily unavailable/i)).toBeInTheDocument();
+  });
+
+  it('shows partial error message when some APIs fail', async () => {
+    await mockAllApis({ failQualifications: true });
+    setUser();
+    render(<Wrapper />);
+
+    expect(await screen.findByText(/some dashboard sections could not load/i)).toBeInTheDocument();
+    expect(screen.getByText('Team Members')).toBeInTheDocument();
+  });
+
+  it('works for supervisor role', async () => {
+    await mockAllApis();
+    setUser(supervisorUser);
+    render(<Wrapper />);
+
+    expect(await screen.findByRole('heading', { name: /manager dashboard/i })).toBeInTheDocument();
+    expect(screen.getByText('Team Members')).toBeInTheDocument();
+  });
+
+  it('handles empty user session', async () => {
+    await mockAllApis();
+    render(<Wrapper />);
+
+    expect(await screen.findByText(/couldn't find a signed-in user session/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/styles/manager-dashboard.css
+++ b/apps/web/src/styles/manager-dashboard.css
@@ -1,0 +1,398 @@
+/* Manager Dashboard — analytics layout */
+
+.mgr-dashboard {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.mgr-dashboard__section {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-white);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.05);
+}
+
+.mgr-dashboard__section h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+/* Stat cards grid */
+
+.mgr-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.mgr-stat-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.mgr-stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1.25rem;
+  border-radius: 0.875rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-gray-50);
+  transition: box-shadow 0.2s ease;
+}
+
+.mgr-stat-card:hover {
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+}
+
+.mgr-stat-card--healthy {
+  border-left: 4px solid var(--color-success);
+}
+
+.mgr-stat-card--warning {
+  border-left: 4px solid var(--color-warning);
+}
+
+.mgr-stat-card--critical {
+  border-left: 4px solid var(--color-danger);
+}
+
+.mgr-stat-card--neutral {
+  border-left: 4px solid var(--color-primary);
+}
+
+.mgr-stat-card__label {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+  font-weight: 600;
+}
+
+.mgr-stat-card__value {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.mgr-stat-card__subtitle {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+}
+
+/* Progress bar */
+
+.mgr-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mgr-progress__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.mgr-progress__label {
+  font-weight: 600;
+  font-size: 0.875rem;
+}
+
+.mgr-progress__fraction {
+  font-size: 0.875rem;
+  color: var(--color-text-secondary);
+}
+
+.mgr-progress__track {
+  height: 0.75rem;
+  border-radius: 9999px;
+  background: var(--color-gray-100);
+  overflow: hidden;
+}
+
+.mgr-progress__fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #3b82f6 0%, #60a5fa 100%);
+  transition: width 0.3s ease;
+}
+
+.mgr-compliance-bar {
+  padding: 0.5rem 0;
+}
+
+/* Compliance badges */
+
+.mgr-compliance-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.mgr-compliance-badge--compliant {
+  background: rgba(34, 197, 94, 0.12);
+  color: var(--color-success);
+}
+
+.mgr-compliance-badge--at-risk {
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--color-warning);
+}
+
+.mgr-compliance-badge--non-compliant {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--color-danger);
+}
+
+/* Employee table */
+
+.mgr-employee-table {
+  overflow-x: auto;
+}
+
+.mgr-employee-table table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.mgr-employee-table th,
+.mgr-employee-table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.mgr-employee-table th {
+  font-size: 0.8125rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+  background: var(--color-gray-50);
+}
+
+.mgr-employee-table tbody tr:hover {
+  background: rgba(59, 130, 246, 0.04);
+}
+
+.mgr-employee-link {
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.mgr-employee-link:hover {
+  text-decoration: underline;
+}
+
+/* Expiry warning panels */
+
+.mgr-expiry-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-white);
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.05);
+}
+
+.mgr-expiry-panel h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.mgr-expiry-empty {
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.mgr-expiry-summary {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.mgr-expiry-summary__count {
+  padding: 0.375rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.mgr-expiry-summary__count--critical {
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--color-danger);
+}
+
+.mgr-expiry-summary__count--warning {
+  background: rgba(245, 158, 11, 0.12);
+  color: var(--color-warning);
+}
+
+.mgr-expiry-summary__count--caution {
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--color-primary);
+}
+
+.mgr-expiry-bucket {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mgr-expiry-bucket__title {
+  margin: 0;
+  font-size: 0.875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-text-secondary);
+}
+
+.mgr-expiry-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mgr-expiry-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-gray-50);
+}
+
+.mgr-expiry-item--overdue {
+  border-left: 4px solid var(--color-danger);
+  background: rgba(239, 68, 68, 0.04);
+}
+
+.mgr-expiry-item--critical {
+  border-left: 4px solid var(--color-danger);
+}
+
+.mgr-expiry-item--warning {
+  border-left: 4px solid var(--color-warning);
+}
+
+.mgr-expiry-item--caution {
+  border-left: 4px solid var(--color-primary);
+}
+
+.mgr-expiry-item__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.mgr-expiry-item__name {
+  font-weight: 600;
+}
+
+.mgr-expiry-item__employee,
+.mgr-expiry-item__type {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+}
+
+.mgr-expiry-item__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.15rem;
+}
+
+.mgr-expiry-item__date {
+  font-size: 0.8125rem;
+  color: var(--color-text-secondary);
+}
+
+.mgr-expiry-item__countdown {
+  font-size: 0.8125rem;
+  font-weight: 700;
+}
+
+.mgr-expiry-item--overdue .mgr-expiry-item__countdown,
+.mgr-expiry-item--critical .mgr-expiry-item__countdown {
+  color: var(--color-danger);
+}
+
+.mgr-expiry-item--warning .mgr-expiry-item__countdown {
+  color: var(--color-warning);
+}
+
+/* Quick actions */
+
+.mgr-quick-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+
+.mgr-quick-action {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.875rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border);
+  background: linear-gradient(180deg, rgba(59, 130, 246, 0.06) 0%, rgba(255, 255, 255, 1) 100%);
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 700;
+  font-size: 0.875rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.mgr-quick-action:hover {
+  transform: translateY(-2px);
+  border-color: rgba(59, 130, 246, 0.35);
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+}
+
+/* Responsive */
+
+@media (max-width: 768px) {
+  .mgr-stat-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .mgr-expiry-item {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .mgr-expiry-item__meta {
+    align-items: flex-start;
+  }
+
+  .mgr-quick-actions {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 480px) {
+  .mgr-stat-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mgr-expiry-summary {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary

Builds a Manager Analytics Dashboard at \/dashboard/manager\ (SUPERVISOR+ only) — closes #22.

### What's new

- **ManagerDashboardPage** — Single-page analytics view with team compliance overview, template assignment progress, expiring items (30/60/90-day buckets), employee status table, and quick action links
- **4 reusable dashboard components** in \components/dashboard/\:
  - **StatCard** — Labeled value card with tone variants (healthy/warning/critical/neutral)
  - **ProgressBar** — Accessible progress bar with label, fraction, and ARIA attributes
  - **ComplianceStatusBadge** — Compliance status pill
  - **ExpiryWarningList** — Bucketed expiry warning panel with urgency tiers
- **Route** added at \/dashboard/manager\ with SUPERVISOR+ RBAC gating
- **Nav link** ('Analytics') added for supervisor+ roles in sidebar

### API endpoints consumed
- \GET /api/employees\ — team member list with compliance status
- \GET /api/assignments/team\ — template assignments with completion tracking
- \GET /api/qualifications\ — qualifications with expiry dates
- \GET /api/medical\ — medical clearances with expiry dates

### Testing
- 39 new tests (12 page-level + 27 component-level)
- All 145 web tests passing (20 test files)
- No new typecheck errors introduced
- Partial-failure resilience tested (1 or all endpoints failing)

### Design decisions
- Separate page from home dashboard to keep personal workspace lightweight
- \Promise.allSettled\ for resilient multi-endpoint fetching with partial-failure UX
- Components are generic and reusable beyond the dashboard context