### PR TITLE
fix: lazy Prisma client initialization

### DIFF
--- a/.squad/agents/bunk/history.md
+++ b/.squad/agents/bunk/history.md
@@ -375,4 +375,6 @@ Decision file: N/A (straightforward test addition, no architectural decisions)
 
 **Test Results:** 42/42 identity tests passing. No regressions — 785 passing total, pre-existing failures unchanged.
 
+- 2026-07-18: Issue #220 — Lazy Prisma client initialization. Refactored `apps/api/src/config/database.ts` to use a Proxy-based lazy singleton: PrismaClient is NOT instantiated at module evaluation time, only on first property access. Also made `apps/api/src/config/env.ts` fully lazy — env validation no longer runs at import time, deferred to first `env.X` access or `loadEnv()` call. Both changes fix test setup ordering: `setup.ts` env vars are now guaranteed to be set before any Prisma or env initialization. Added `getPrismaClient()` for direct access and `_resetPrismaClient()` for test isolation. Proxy pattern preserves the `prisma` export name — zero consumer changes needed. Branch: squad/220-prisma-lazy-init.
+
 

--- a/.squad/decisions/inbox/bunk-prisma-lazy-init.md
+++ b/.squad/decisions/inbox/bunk-prisma-lazy-init.md
@@ -1,0 +1,30 @@
+# Decision: Lazy Prisma Client Initialization
+
+**Author:** Bunk  
+**Date:** 2026-07-18  
+**Issue:** #220  
+**Branch:** squad/220-prisma-lazy-init  
+
+## Context
+
+Integration test suites (documents, employees, medical, notifications, qualifications, standards) failed because `apps/api/src/config/database.ts` instantiated PrismaClient at module evaluation time. When test files imported `createApp`, the import chain triggered PrismaClient creation before the test setup file (`apps/api/tests/setup.ts`) could set environment variables like `DATABASE_URL` and `JWT_SECRET`.
+
+Similarly, `apps/api/src/config/env.ts` eagerly parsed and validated env vars at import time (line 42), which could call `process.exit(1)` before test env vars were set.
+
+## Decision
+
+1. **database.ts** — Replace eager `export const prisma = createPrismaClient()` with a `Proxy`-based lazy singleton. The Proxy defers PrismaClient instantiation to first property access. Export name `prisma` is preserved, so zero consumer changes are required.
+
+2. **env.ts** — Remove eager `parseEnv()` call at module scope. The `env` Proxy now lazily validates on first property access. `loadEnv()` handles both keyvault and non-keyvault paths.
+
+## Rationale
+
+- **Proxy pattern** was chosen over function-based access (`getPrismaClient()`) to avoid touching 22+ consumer files. The Proxy transparently forwards all property access and method calls.
+- **Lazy env validation** ensures test setup files can set env vars before validation runs, without changing the API for production code (which calls `loadEnv()` at startup).
+- Both changes are backward-compatible — no consumer modifications needed.
+
+## Impact
+
+- All 6 affected integration test suites now load without initialization errors
+- Production startup path unchanged (PrismaClient created on first use, env validated on first access or `loadEnv()`)
+- Added `_resetPrismaClient()` utility for future test isolation needs

--- a/apps/api/src/config/database.ts
+++ b/apps/api/src/config/database.ts
@@ -6,7 +6,7 @@ type GlobalPrisma = typeof globalThis & {
 };
 
 function createPrismaClient() {
-  const prisma = new PrismaClient({
+  const client = new PrismaClient({
     log:
       process.env.NODE_ENV === "development"
         ? [
@@ -18,7 +18,7 @@ function createPrismaClient() {
   });
 
   if (process.env.NODE_ENV === "development") {
-    prisma.$on("query", (event: Prisma.QueryEvent) => {
+    client.$on("query", (event: Prisma.QueryEvent) => {
       logger.debug("Prisma query", {
         durationMs: event.duration,
         query: event.query,
@@ -27,20 +27,40 @@ function createPrismaClient() {
     });
   }
 
-  return prisma;
+  return client;
 }
 
-const globalForPrisma = globalThis as GlobalPrisma;
+// Lazy singleton — PrismaClient is NOT created until first use
+let _client: PrismaClient | undefined;
 
-export const prisma = globalForPrisma.__eClatPrisma ?? createPrismaClient();
-
-if (process.env.NODE_ENV !== "production") {
-  globalForPrisma.__eClatPrisma = prisma;
+export function getPrismaClient(): PrismaClient {
+  if (!_client) {
+    const g = globalThis as GlobalPrisma;
+    _client = g.__eClatPrisma ?? createPrismaClient();
+    if (process.env.NODE_ENV !== "production") {
+      g.__eClatPrisma = _client;
+    }
+  }
+  return _client;
 }
+
+/**
+ * Lazy proxy over PrismaClient. All property access is deferred until first
+ * use, so the real client is only created after env vars (DATABASE_URL, etc.)
+ * have been set — critical for test setup ordering.
+ */
+export const prisma: PrismaClient = new Proxy({} as PrismaClient, {
+  get(_target, prop) {
+    const client = getPrismaClient();
+    const value = Reflect.get(client, prop);
+    return typeof value === "function" ? (value as Function).bind(client) : value;
+  },
+});
 
 export async function disconnectDatabase(context = "shutdown") {
+  if (!_client) return;
   try {
-    await prisma.$disconnect();
+    await _client.$disconnect();
     logger.info(`Prisma client disconnected (${context})`);
   } catch (error) {
     const disconnectError = error instanceof Error ? error : new Error(String(error));
@@ -51,4 +71,11 @@ export async function disconnectDatabase(context = "shutdown") {
     });
     throw disconnectError;
   }
+}
+
+/** Reset the singleton — for tests only. */
+export function _resetPrismaClient() {
+  _client = undefined;
+  const g = globalThis as GlobalPrisma;
+  delete g.__eClatPrisma;
 }

--- a/apps/api/src/config/env.ts
+++ b/apps/api/src/config/env.ts
@@ -39,11 +39,18 @@ function parseEnv(source: NodeJS.ProcessEnv) {
   return result.data;
 }
 
-let envState: Env | undefined = process.env.KEY_VAULT_URI ? undefined : parseEnv(process.env);
+// Env state is lazily initialized — never parsed at module evaluation time.
+// This lets test setup files set env vars before validation runs.
+let envState: Env | undefined;
 let envPromise: Promise<Env> | undefined;
 
 export async function loadEnv() {
   if (envState) {
+    return envState;
+  }
+
+  if (!process.env.KEY_VAULT_URI) {
+    envState = parseEnv(process.env);
     return envState;
   }
 
@@ -68,7 +75,10 @@ export async function loadEnv() {
 export const env = new Proxy({} as Env, {
   get(_target, property) {
     if (!envState) {
-      throw new Error("Environment not initialized. Call loadEnv() before accessing env when KEY_VAULT_URI is set.");
+      if (process.env.KEY_VAULT_URI) {
+        throw new Error("Environment not initialized. Call loadEnv() before accessing env when KEY_VAULT_URI is set.");
+      }
+      envState = parseEnv(process.env);
     }
 
     return envState[property as keyof Env];


### PR DESCRIPTION
## Summary

Refactors \pps/api/src/config/database.ts\ and \pps/api/src/config/env.ts\ to use lazy initialization patterns, fixing 6 integration test suites that failed because PrismaClient was instantiated at module evaluation time — before test setup could set environment variables.

### Changes

**database.ts** — Replaced eager \xport const prisma = createPrismaClient()\ with a \Proxy\-based lazy singleton. PrismaClient is only created on first property access. The \prisma\ export name is preserved, so zero consumer changes are needed.

**env.ts** — Removed eager \parseEnv()\ call at module scope. The \nv\ Proxy now lazily validates on first property access. \loadEnv()\ handles both keyvault and non-keyvault paths.

### Testing

- All 6 previously-failing integration test suites (documents, employees, medical, notifications, qualifications, standards) now load without initialization errors
- 281 unit/integration tests pass; 96 pre-existing negative test failures unchanged
- API and shared packages typecheck clean

Closes #220