### PR TITLE
fix(web): resolve TypeScript errors in web package (#242)

### DIFF
--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -72,6 +72,12 @@ export const api = {
       body: body ? JSON.stringify(body) : undefined,
     }),
   
+  patch: <T>(path: string, body?: unknown) =>
+    request<T>(path, {
+      method: 'PATCH',
+      body: body ? JSON.stringify(body) : undefined,
+    }),
+  
   del: (path: string) => request<void>(path, { method: 'DELETE' }),
 };
 

--- a/apps/web/src/pages/TemplateEditorPage.tsx
+++ b/apps/web/src/pages/TemplateEditorPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { api } from '../api/client';
 import PageShell from '../components/PageShell';
 import {

--- a/apps/web/src/pages/TemplateFulfillmentPage.tsx
+++ b/apps/web/src/pages/TemplateFulfillmentPage.tsx
@@ -137,7 +137,8 @@ export default function TemplateFulfillmentPage() {
     return sortTemplateRequirements(template?.requirements ?? []).map((requirement) => {
       const fulfillment = fulfillments.find((item) => item.requirementId === requirement.id) ?? null;
       const attachedDocumentId = fulfillment?.documentId ?? fulfillment?.attachedDocumentId ?? null;
-      const evidenceDocuments = attachedDocumentId ? [documentMap.get(attachedDocumentId)].filter(Boolean) : [];
+      const doc = attachedDocumentId ? documentMap.get(attachedDocumentId) : undefined;
+      const evidenceDocuments = doc ? [doc] : [];
 
       return {
         requirement,

--- a/apps/web/src/pages/__tests__/MyDocuments.test.tsx
+++ b/apps/web/src/pages/__tests__/MyDocuments.test.tsx
@@ -6,7 +6,6 @@ import MyDocumentsPage from '../MyDocuments';
 import { AuthProvider } from '../../contexts/AuthContext';
 import { FeatureFlagsProvider } from '../../hooks/useFeatureFlags';
 import type { EmployeeDocument } from '../../types/my-section';
-import { ApiError } from '../../api/client';
 
 vi.mock('../../api/client', () => ({
   api: {

--- a/apps/web/src/pages/__tests__/MyHours.test.tsx
+++ b/apps/web/src/pages/__tests__/MyHours.test.tsx
@@ -4,7 +4,6 @@ import { BrowserRouter } from 'react-router-dom';
 import MyHoursPage from '../MyHours';
 import { AuthProvider } from '../../contexts/AuthContext';
 import { FeatureFlagsProvider } from '../../hooks/useFeatureFlags';
-import { ApiError } from '../../api/client';
 
 vi.mock('../../api/client', () => ({
   api: {

--- a/apps/web/src/types/my-section.ts
+++ b/apps/web/src/types/my-section.ts
@@ -93,6 +93,15 @@ export interface MedicalRecord {
   updatedAt?: string;
 }
 
+export interface MedicalClearance {
+  id: string;
+  clearanceType: string;
+  status: string;
+  expiresAt?: string | null;
+  expirationDate?: string | null;
+  documentCount?: number;
+}
+
 export interface EmployeeDocument {
   id: string;
   employeeId?: string;


### PR DESCRIPTION
## Summary
Fixes all 9 TypeScript errors in the @e-clat/web package:

1. **Unused imports**: Removed unused ApiError imports from MyDocuments.test.tsx and MyHours.test.tsx
2. **Missing export**: Added MedicalClearance type export to types/my-section.ts
3. **Missing API method**: Added patch method to the HTTP client API type definition
4. **Unused import**: Removed unused Link import from TemplateEditorPage.tsx
5. **Type safety**: Fixed document type safety in TemplateFulfillmentPage.tsx

## Validation
- ✅ npm run typecheck -w @e-clat/web passes with 0 errors
- ✅ All TypeScript errors resolved

## Issue Reference
closes #242

## Risk
- Risk level: low
- Changes are minimal and non-functional
- Rollback: Revert to previous commit